### PR TITLE
Fix a small path resolution issue

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+# 2.0.0-a5
+
+* Fix a small path resolution issue.
+
 # 2.0.0-a4
 
 * Add basic CI that builds for Linux, macOS and Docker

--- a/openlane/__version__.py
+++ b/openlane/__version__.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-__version__ = "2.0.0a4-1"
+__version__ = "2.0.0a5"
 
 if __name__ == "__main__":
     print(__version__, end="")

--- a/openlane/config/builder.py
+++ b/openlane/config/builder.py
@@ -187,6 +187,7 @@ class ConfigBuilder(object):
                 raise TypeError(
                     "The argument design_dir is not supported when config_in is not a dictionary."
                 )
+            config_in = os.path.abspath(config_in)
 
             design_dir = str(os.path.dirname(config_in))
             config_in = str(config_in)
@@ -339,15 +340,7 @@ class ConfigBuilder(object):
             "Support for .tcl configuration files is deprecated. Please migrate to a .json file at your earliest convenience."
         )
 
-        try:
-            import volare
-
-            pdk_root = volare.get_volare_home(pdk_root)
-        except ImportError:
-            if pdk_root is None:
-                raise ValueError(
-                    "The pdk_root argument is required as Volare is not installed."
-                )
+        pdk_root = Self._resolve_pdk_root(pdk_root)
 
         config_in = Config(
             {
@@ -358,7 +351,7 @@ class ConfigBuilder(object):
 
         tcl_vars_in = config_in.copy()
         tcl_vars_in[Keys.scl] = ""
-        tcl_vars_in[Keys.design_dir] = os.path.abspath(design_dir)
+        tcl_vars_in[Keys.design_dir] = design_dir
         tcl_config = env_from_tcl(tcl_vars_in, config)
 
         process_info = resolve(
@@ -383,7 +376,7 @@ class ConfigBuilder(object):
 
         tcl_vars_in[Keys.pdk] = pdk
         tcl_vars_in[Keys.scl] = scl
-        tcl_vars_in[Keys.design_dir] = os.path.abspath(design_dir)
+        tcl_vars_in[Keys.design_dir] = design_dir
 
         design_config = env_from_tcl(tcl_vars_in, config)
 
@@ -407,9 +400,22 @@ class ConfigBuilder(object):
         for warning in design_warnings:
             warn(warning)
 
-        config_in["PDK_ROOT"] = os.path.abspath(pdk_root)
+        config_in["PDK_ROOT"] = pdk_root
 
         return config_in
+
+    @classmethod
+    def _resolve_pdk_root(Self, pdk_root: Optional[str]) -> str:
+        try:
+            import volare
+
+            pdk_root = volare.get_volare_home(pdk_root)
+        except ImportError:
+            if pdk_root is None:
+                raise ValueError(
+                    "The pdk_root argument is required as Volare is not installed."
+                )
+        return os.path.abspath(pdk_root)
 
     @classmethod
     def _get_pdk_config(
@@ -422,15 +428,7 @@ class ConfigBuilder(object):
         """
         :returns: A tuple of the PDK configuration, the PDK path and the SCL.
         """
-        try:
-            import volare
-
-            pdk_root = volare.get_volare_home(pdk_root)
-        except ImportError:
-            if pdk_root is None:
-                raise ValueError(
-                    "The pdk_root argument is required as Volare is not installed."
-                )
+        pdk_root = Self._resolve_pdk_root(pdk_root)
 
         config_in = Config(
             {


### PR DESCRIPTION
If `dirname` returns an empty string, the flow would crash. I moved the abspath earlier.