### PR TITLE
Apply `stream_out` fix to other KLayout scripts

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+# 2.0.0-a12
+* Fixes a bug where if OpenLane is invoked from the same directory as the design,
+  KLayout stream-outs would break.
+
 # 2.0.0-a11
 * Update OpenROAD, Add ABC patch to use system zlib
 * Adds SDC files as an input to `OpenROADStep`, `NetlistSTA` and `LayoutSTA` steps

--- a/openlane/__version__.py
+++ b/openlane/__version__.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-__version__ = "2.0.0a11"
+__version__ = "2.0.0a12"
 
 if __name__ == "__main__":
     print(__version__, end="")

--- a/openlane/scripts/klayout/open_design.py
+++ b/openlane/scripts/klayout/open_design.py
@@ -59,7 +59,11 @@ else:
             args.append("-rd")
             if isinstance(value, tuple) or isinstance(value, list):
                 value = ";".join(value)
-            elif isinstance(value, str) and os.path.exists(value):
+            elif (
+                isinstance(value, str)
+                and os.path.exists(value)
+                and key != "design_name"
+            ):
                 value = os.path.abspath(value)
 
             args.append(f"{key}={value or 'NULL'}")

--- a/openlane/scripts/klayout/render.py
+++ b/openlane/scripts/klayout/render.py
@@ -93,7 +93,11 @@ else:
             args.append("-rd")
             if isinstance(value, tuple) or isinstance(value, list):
                 value = ";".join(value)
-            elif isinstance(value, str) and os.path.exists(value):
+            elif (
+                isinstance(value, str)
+                and os.path.exists(value)
+                and key != "design_name"
+            ):
                 value = os.path.abspath(value)
 
             args.append(f"{key}={value or 'NULL'}")


### PR DESCRIPTION
This is not strictly necessary as that variable is not used in those scripts yet, but won't hurt for the future.