### PR TITLE
Assorted Bugfixes

### DIFF
--- a/openlane/__main__.py
+++ b/openlane/__main__.py
@@ -199,12 +199,10 @@ def run_smoke_test(
             cmd += ["--pdk-root", pdk_root]
 
         if dockerized:
-            cmd += ["--dockerized"]
-
-            docker_mounts = [d] + list(ctx.params.get("docker_mounts"))
-
-            for mount in docker_mounts:
-                cmd += ["--docker-mount", mount]
+            cmd += ["--dockerized", "--docker-mount", d]
+            if extra_mounts := ctx.params.get("docker_mounts"):
+                for mount in extra_mounts:
+                    cmd += ["--docker-mount", mount]
 
         try:
             subprocess.check_call(cmd)

--- a/openlane/config/builder.py
+++ b/openlane/config/builder.py
@@ -107,6 +107,8 @@ class ConfigBuilder(object):
             Useful examples are CLOCK_PORT, CLOCK_PERIOD, et cetera, which while
             not bound to a specific :class:`Step`, affects most Steps' behavior.
         """
+        PDK_ROOT = Self._resolve_pdk_root(PDK_ROOT)
+
         config_in, _, _ = Self._get_pdk_config(
             PDK,
             STD_CELL_LIBRARY,


### PR DESCRIPTION
Includes 34341ce66c36b506f43276486b177b1adcd6ed8b, which was pushed to main by accident

---

* Updated the smoke test to support PDK downloads to a different directory.
* Updated config builder to resolve the PDK root much earlier to avoid an issue where a crash would affect the issue reproducible.
* Updated `SYNTH_READ_BLACKBOX_LIB` to read the full `LIB` variable instead of `LIB_SYNTH`, which also fixes a crash when reading JSON headers.
* Updated post-GRT resizer timing script to re-run GRT before the repair: see https://github.com/The-OpenROAD-Project/OpenROAD/issues/3155
* Added a "yosys proc" to the JSON header generator (thanks @smnaut)
* Fixed a bug where random equidistant mode did not work for OpenROAD IO placer.

---

Resolves #40, Resolves #38
