### PR TITLE
`SequentialFlow` Ergonomics

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,6 +10,6 @@ build:
   tools:
     python: "3.10"
   commands:
-    - pip3 install -r ./requirements_dev.txt -r ./requirements.txt
+    - pip3 install -r ./requirements_docs.txt -r ./requirements.txt
     - cd docs && python3 -m sphinx.cmd.build -M html "source" "_build"
     - mv docs/_build _readthedocs

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,19 @@
+# 2.0.0-a27
+
+* Added `cloup` library for better argument grouping/prettier `--help` with click
+* Added ability to substitute steps with a certain `id` in a `SequentialFlow`
+  with other Step classes
+* Added `--only`, `--skip` to commandline interface for `SequentialFlow`s
+* Changed processing of how `--from` and `--to` are done in `SequentialFlow`s
+* Better delineation of class vs. instance variables in documentation
+* Type checker now also checks functions without typed headers
+* Fixed minor bugs with `Decimal` serialization and deserialization
+* Class/step registry now case-insensitive
+* Moved documentation dependencies to separate requirements file
+* Removed `jupyter` from `requirements_dev.txt`- too many dependencies and can
+  just be installed with `pip install jupyter`
+* Various documentation improvements and fixes
+
 # 2.0.0-a26
 
 * Yosys steps now read macro netlists as a black-box if applicable

--- a/Makefile
+++ b/Makefile
@@ -5,11 +5,11 @@ dist: venv/manifest.txt
 
 .PHONY: mount
 mount:
-	@echo "make mount is not needed in OpenLane 2. You may simply call 'openlane --dockerized'."
+	@echo "make mount is not needed in OpenLane 2+. You may simply call 'openlane --dockerized'."
 
 .PHONY: pdk pull-openlane
 pdk pull-openlane:
-	@echo "This command is not needed in OpenLane 2."
+	@echo "OpenLane 2+ will automatically pull PDKs and/or Docker containers when it needs them."
 
 .PHONY: openlane
 openlane:
@@ -29,7 +29,7 @@ docs: venv
 lint: venv/manifest.txt
 	./venv/bin/black --check .
 	./venv/bin/flake8 .
-	./venv/bin/mypy .
+	./venv/bin/mypy --check-untyped-defs .
 
 .PHONY: test
 test: venv/manifest.txt
@@ -48,15 +48,18 @@ check-license: venv/manifest.txt
 		java -jar app.jar \
 		--requirements '/volume/requirements.frz.txt'
 
+REQ_FILES = ./requirements_dev.txt ./requirements.txt
+REQ_FILES_PFX = $(addprefix -r ,$(REQ_FILES))
+
 venv: venv/manifest.txt
-venv/manifest.txt: ./requirements_dev.txt ./requirements.txt
+venv/manifest.txt: $(REQ_FILES) Makefile
 	rm -rf venv
 	python3 -m venv ./venv
 	PYTHONPATH= ./venv/bin/python3 -m pip install --upgrade pip
 	PYTHONPATH= ./venv/bin/python3 -m pip install --upgrade wheel
-	PYTHONPATH= ./venv/bin/python3 -m pip install --upgrade -r ./requirements_dev.txt -r ./requirements.txt
-	PYTHONPATH= ./venv/bin/mypy --install-types --non-interactive . || true
+	PYTHONPATH= ./venv/bin/python3 -m pip install --upgrade $(REQ_FILES_PFX)
 	PYTHONPATH= ./venv/bin/python3 -m pip freeze > $@
+	@echo ">> Venv prepared. To install documentation dependencies, invoke './venv/bin/python3 -m pip install --upgrade -r requirements_docs.txt'"
 
 .PHONY: veryclean
 veryclean: clean

--- a/default.nix
+++ b/default.nix
@@ -68,6 +68,7 @@ with pkgs; with python3.pkgs; buildPythonPackage rec {
 
     # Python
     click
+    cloup
     pyyaml
     rich
     requests

--- a/openlane/__version__.py
+++ b/openlane/__version__.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-__version__ = "2.0.0a26"
+__version__ = "2.0.0a27"
 
 if __name__ == "__main__":
     print(__version__, end="")

--- a/openlane/config/builder.py
+++ b/openlane/config/builder.py
@@ -67,13 +67,6 @@ class InvalidConfig(ValueError):
         super().__init__(message, *args, **kwargs)
 
 
-class DecimalDecoder(json.JSONDecoder):
-    def default(self, o):
-        if isinstance(o, float) or isinstance(o, int):
-            return Decimal(o)
-        return super(DecimalDecoder, self).default(o)
-
-
 class ConfigBuilder(object):
     """
     Various constructors for OpenLane configuration objects.
@@ -242,7 +235,7 @@ class ConfigBuilder(object):
         *args,
         **kwargs,
     ):
-        raw = json.loads(json_str, cls=DecimalDecoder)
+        raw = json.loads(json_str, parse_float=Decimal)
         kwargs["resolve_json"] = True
         return Self._load_dict(
             raw,

--- a/openlane/config/config.py
+++ b/openlane/config/config.py
@@ -57,8 +57,6 @@ class ConfigEncoder(json.JSONEncoder):
         elif isinstance(o, Path):
             return str(o)
         elif isinstance(o, Enum):
-            return str(o)
-        elif isinstance(o, StringEnum):
             return o.value
         return super(ConfigEncoder, self).default(o)
 

--- a/openlane/config/variable.py
+++ b/openlane/config/variable.py
@@ -174,7 +174,7 @@ class Variable:
         Returns the type of a variable presuming it is not None.
 
         If a variable is not Optional, that is simply the type specified in the
-        :attr:`type` field.
+        :ivar:`type` field.
         """
         return some_of(self.type)
 

--- a/openlane/steps/checker.py
+++ b/openlane/steps/checker.py
@@ -40,17 +40,17 @@ class MetricChecker(Step):
         return super().get_help_md(dynamic_docstring)
 
     @abstractmethod
-    def get_metric_name(self) -> str:
+    def get_metric_name(self: Optional["MetricChecker"]) -> str:
         raise NotImplementedError()
 
     @abstractmethod
-    def get_metric_description(self) -> str:
+    def get_metric_description(self: Optional["MetricChecker"]) -> str:
         raise NotImplementedError()
 
-    def get_threshold(self) -> Optional[Decimal]:
+    def get_threshold(self: Optional["MetricChecker"]) -> Optional[Decimal]:
         return Decimal(0)
 
-    def get_threshold_description(self) -> Optional[str]:
+    def get_threshold_description(self: Optional["MetricChecker"]) -> Optional[str]:
         return None
 
     def run(self, state_in: State, **kwargs) -> State:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
-click>=8.0.0,<9
+click>=8,<9
+cloup>=1,<2
 pyyaml>=5,<7
 rich>=12,<13
-requests>=2.27.0,<3
+requests>=2.27,<3
 volare>=0.7.1
 lxml>=4.9.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -6,17 +6,21 @@ black>=22.3.0,<23
 black[jupyter]
 flake8>=4.0.1
 flake8-no-implicit-concat==0.3.3
-mypy
 
-# docs
-furo
-docutils>=0.17
-sphinx>=4
-sphinx-autobuild>=2021.3.14
-sphinx-autodoc-typehints
-myst-parser>=0.18.0
-docstring-parser
+## mypy
+mypy
+lxml-stubs
+types-urllib3
+types-typed-ast
+types-six
+types-setuptools
+types-PyYAML
+types-docutils
+types-decorator
+types-commonmark
+types-colorama
+types-requests
+types-Pygments
 
 # ide
 pylance
-jupyter

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -1,0 +1,8 @@
+# docs
+furo
+docutils>=0.17
+sphinx>=4
+sphinx-autobuild>=2021.3.14
+sphinx-autodoc-typehints
+myst-parser>=0.18.0
+docstring-parser


### PR DESCRIPTION
* Added `cloup` library for better argument grouping/prettier `--help` with click
* Added ability to substitute steps with a certain `id` in a `SequentialFlow`
  with other Step classes
* Added `--only`, `--skip` to commandline interface for `SequentialFlow`s
* Changed processing of how `--from` and `--to` are done in `SequentialFlow`s
* Better delineation of class vs. instance variables in documentation
* Type checker now also checks functions without typed headers
* Fixed minor bugs with `Decimal` serialization and deserialization
* Class/step registry now case-insensitive
* Moved documentation dependencies to separate requirements file
* Removed `jupyter` from `requirements_dev.txt`- too many dependencies and can
  just be installed with `pip install jupyter`
* Various documentation improvements and fixes
