### PR TITLE
Better Thread Handling

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,7 +4,7 @@
 * Added a global ThreadPoolExecutor object for all subprocesses to `common`.
   * Accessible for external scripts and plugins via `openlane.get_tpe` and `openlane.set_tpe`
 * Folded `--list-plugins` into `--version`
-* Renamed `ROUTING_CORES` to `ROUTING_THREADS`
+* Renamed `ROUTING_CORES` to `DRT_THREADS`
 * Removed `RCX_CORES`, step now uses global ThreadPoolExecutor
 
 # 2.0.0-a35

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,12 @@
+# 2.0.0-a36
+
+* Added a commandline option `-j/--jobs` to add a maximum cap on subprocesses.
+* Added a global ThreadPoolExecutor object for all subprocesses to `common`.
+  * Accessible for external scripts and plugins via `openlane.get_tpe` and `openlane.set_tpe`
+* Folded `--list-plugins` into `--version`
+* Renamed `ROUTING_CORES` to `ROUTING_THREADS`
+* Removed `RCX_CORES`, step now uses global ThreadPoolExecutor
+
 # 2.0.0-a35
 
 * Revert magic to [`a33d7b7`](https://github.com/RTimothyEdwards/magic/commit/a33d7b78b54d8456769d08236f91f9be31784267),

--- a/docs/source/usage/hardening_macros.md
+++ b/docs/source/usage/hardening_macros.md
@@ -253,12 +253,12 @@ During global routing, you can set [`GRT_REPAIR_ANTENNAS`](../reference/step_con
 This will enable diode insertion during global routing for long nets, which will
 mitigate the effect. This is enabled by default.
 
-### `ROUTING_CORES`
+### `DRT_THREADS`
 
 By default, detailed routing, which is the most computationally expensive step
 in the flow, will use all available threads on your computer by default.
 You can decrease that by overriding the step variable
-[`ROUTING_CORES`](../reference/step_config_vars.md#OpenROAD.DetailedRouting.ROUTING_CORES).
+[`DRT_THREADS`](../reference/step_config_vars.md#OpenROAD.DetailedRouting.DRT_THREADS).
 
 Be advised that higher is always better for runtime.
 

--- a/openlane/__main__.py
+++ b/openlane/__main__.py
@@ -21,6 +21,7 @@ import traceback
 import subprocess
 from textwrap import dedent
 from functools import partial
+from concurrent.futures import ThreadPoolExecutor
 from typing import Tuple, Type, Optional, List, Union
 
 import click
@@ -28,7 +29,6 @@ from cloup import (
     option,
     option_group,
     command,
-    version_option,
     HelpFormatter,
     HelpTheme,
     Style,
@@ -51,10 +51,7 @@ from .logging import (
     warn,
     info,
 )
-from .common import (
-    get_opdks_rev,
-    get_openlane_root,
-)
+from . import common
 from .container import run_in_container
 from .plugins import discovered_plugins
 from .config import Config, InvalidConfig
@@ -94,7 +91,7 @@ def run(
 
         pdk_root = volare.get_volare_home(pdk_root)
 
-        volare.enable(pdk_root, pdk[:-1], get_opdks_rev())
+        volare.enable(pdk_root, pdk[:-1], common.get_opdks_rev())
 
     config_file = config_files[0]
 
@@ -188,6 +185,33 @@ def run(
     return 0
 
 
+def print_version(ctx: click.Context, param: click.Parameter, value: bool):
+    if not value:
+        return
+
+    message = dedent(
+        f"""
+        OpenLane v{__version__}
+
+        Copyright ©2020-2023 Efabless Corporation and other contributors.
+
+        Available under the Apache License, version 2. Included with the source code,
+        but you can also get a copy at https://www.apache.org/licenses/LICENSE-2.0
+
+        Included tools and utilities may be distributed under stricter licenses.
+        """
+    ).strip()
+
+    print(message)
+
+    if len(discovered_plugins) > 0:
+        print("Discovered plugins:")
+        for name, module in discovered_plugins.items():
+            print(f"{name} -> {module.__version__}")
+
+    ctx.exit(0)
+
+
 def print_bare_version(
     ctx: click.Context,
     param: click.Parameter,
@@ -209,12 +233,11 @@ def run_smoke_test(
 
     status = 0
     d = tempfile.mkdtemp("openlane2")
+    final_path = os.path.join(d, "smoke_test_design")
     try:
-        final_path = os.path.join(d, "smoke_test_design")
-
         # 1. Copy the files
         shutil.copytree(
-            os.path.join(get_openlane_root(), "smoke_test_design"),
+            os.path.join(common.get_openlane_root(), "smoke_test_design"),
             final_path,
             symlinks=False,
         )
@@ -230,7 +253,7 @@ def run_smoke_test(
         status = run(
             ctx,
             flow_name=None,
-            use_volare=True,
+            use_volare=ctx.params.get("use_volare"),
             pdk_root=pdk_root,
             pdk="sky130A",
             scl=None,
@@ -254,7 +277,7 @@ def run_smoke_test(
         status = -1
     finally:
         try:
-            pass  # shutil.rmtree(d)
+            shutil.rmtree(final_path)
         except FileNotFoundError:
             pass
 
@@ -298,23 +321,10 @@ def cli_in_container(
         ctx.exit(status)
 
 
-def print_plugins(
-    ctx: click.Context,
-    param: click.Parameter,
-    value: bool,
-):
-    if not value:
-        return
-    print(f"openlane -> {__version__}")
-    for name, module in discovered_plugins.items():
-        print(f"{name} -> {module.__version__}")
-    ctx.exit(0)
-
-
 formatter_settings = HelpFormatter.settings(
     theme=HelpTheme(
         invoked_command=Style(fg="bright_yellow"),
-        heading=Style(fg="bright_white", bold=True),
+        heading=Style(fg="cyan", bold=True),
         constraint=Style(fg="magenta"),
         col1=Style(fg="bright_yellow"),
     )
@@ -327,68 +337,33 @@ o = partial(option, show_default=True)
     no_args_is_help=True,
     formatter_settings=formatter_settings,
 )
-@version_option(
-    __version__,
-    prog_name="OpenLane",
-    message=dedent(
-        """
-        %(prog)s v%(version)s
-
-        Copyright ©2020-2023 Efabless Corporation and other contributors.
-
-        Available under the Apache License, version 2. Included with the source code,
-        but you can also get a copy at https://www.apache.org/licenses/LICENSE-2.0
-
-        Included tools and utilities may be distributed under stricter licenses.
-        """
-    ).strip(),
-)
 @option_group(
-    "Docker options",
+    "Containerization options",
     o(
         "--docker-mount",
+        "-m",
         "docker_mounts",
         multiple=True,
-        is_eager=True,
+        is_eager=True,  # docker mount, dockerized should be processed before anything else
         default=[],
-        help="Additionally mount this directory in dockerized mode. Can be supplied multiple times to mount multiple directories. **Must be passed before --docker.**",
+        help="Additionally mount this directory in dockerized mode. Can be supplied multiple times to mount multiple directories. Must be passed before --dockerized.",
     ),
     o(
-        "--dockerized/--native",
+        "--dockerized",
         default=False,
-        is_eager=True,
-        help="Run command primarily using a Docker container. Some caveats apply.",
+        is_flag=True,
+        is_eager=True,  # docker mount, dockerized should be processed before anything else
+        help="Re-invoke using a Docker container. Some caveats apply. Must precede all options except --docker-mount.",
         callback=cli_in_container,
     ),
     constraint=If(~IsSet("dockerized"), accept_none),
-)
-@o(
-    "--bare-version",
-    is_flag=True,
-    is_eager=True,
-    expose_value=False,
-    callback=print_bare_version,
-    hidden=True,
-)
-@o(
-    "--list-plugins",
-    is_flag=True,
-    is_eager=True,
-    expose_value=False,
-    callback=print_plugins,
-    help="List all detected plugins for OpenLane.",
-)
-@o(
-    "--smoke-test",
-    is_flag=True,
-    help="Runs a basic OpenLane smoke test.",
-    callback=run_smoke_test,
 )
 @option_group(
     "PDK options",
     o(
         "--volare-pdk/--manual-pdk",
         "use_volare",
+        is_eager=True,
         default=True,
         help="Automatically use Volare for PDK version installation and enablement. Set --manual if you want to use a custom PDK version.",
     ),
@@ -417,6 +392,30 @@ o = partial(option, show_default=True)
         default=os.environ.pop("STD_CELL_LIBRARY", None),
         help="The standard cell library to use. If None, the PDK's default standard cell library is used.",
     ),
+)
+@option_group(
+    "Subcommands",
+    o(
+        "--version",
+        is_flag=True,
+        is_eager=True,
+        help="Prints version information and exits",
+        callback=print_version,
+    ),
+    o(
+        "--bare-version",
+        is_flag=True,
+        is_eager=True,
+        callback=print_bare_version,
+        hidden=True,
+    ),
+    o(
+        "--smoke-test",
+        is_flag=True,  # Cannot be eager- PDK options need to be processed
+        help="Runs a basic OpenLane smoke test.",
+        callback=run_smoke_test,
+    ),
+    constraint=mutually_exclusive,
 )
 @option_group(
     "Run options",
@@ -510,6 +509,13 @@ o = partial(option, show_default=True)
     )
     + ",".join([f"{name}={value}" for name, value in LogLevelsDict.items()]),
 )
+@o(
+    "-j",
+    "--jobs",
+    type=int,
+    default=os.cpu_count(),
+    help="The maximum number of threads or processes that can be used by OpenLane.",
+)
 @click.argument(
     "config_files",
     nargs=-1,
@@ -520,18 +526,25 @@ o = partial(option, show_default=True)
     ),
 )
 @click.pass_context
-def cli(ctx: click.Context, **kwargs):
-    run_kwargs = kwargs
+def cli(ctx: click.Context, jobs: int, **kwargs):
+    common.set_tpe(ThreadPoolExecutor(max_workers=jobs))
     args = kwargs["config_files"]
+    run_kwargs = kwargs.copy()
+
     if len(args) == 1 and args[0].endswith(".marshalled"):
         run_kwargs = marshal.load(open(args[0], "rb"))
         run_kwargs.update(**{k: kwargs[k] for k in ["pdk_root", "pdk", "scl"]})
-    if "smoke_test" in run_kwargs:
-        del run_kwargs["smoke_test"]
-    if "docker_mounts" in run_kwargs:
-        del run_kwargs["docker_mounts"]
-    if "dockerized" in run_kwargs:
-        del run_kwargs["dockerized"]
+
+    for subcommand_flag in [
+        "docker_mounts",
+        "dockerized",
+        "version",
+        "bare_version",
+        "smoke_test",
+    ]:
+        if subcommand_flag in run_kwargs:
+            del run_kwargs[subcommand_flag]
+
     ctx.exit(run(ctx, **run_kwargs))
 
 

--- a/openlane/__main__.py
+++ b/openlane/__main__.py
@@ -248,12 +248,15 @@ def run_smoke_test(
 
         pdk_root = ctx.params.get("pdk_root")
         config_file = os.path.join(final_path, "config.json")
+        use_volare = True
+        if use_volare_opt := ctx.params.get("use_volare"):
+            use_volare = use_volare_opt
 
         # 3. Run
         status = run(
             ctx,
             flow_name=None,
-            use_volare=ctx.params.get("use_volare"),
+            use_volare=use_volare,
             pdk_root=pdk_root,
             pdk="sky130A",
             scl=None,

--- a/openlane/__version__.py
+++ b/openlane/__version__.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-__version__ = "2.0.0a35"
+__version__ = "2.0.0a36"
 
 if __name__ == "__main__":
     print(__version__, end="")

--- a/openlane/common.py
+++ b/openlane/common.py
@@ -16,8 +16,6 @@ Common Utilities
 
 A number of common utility functions used throughout the codebase.
 """
-from dataclasses import asdict, is_dataclass
-from decimal import Decimal
 import os
 import re
 import json
@@ -25,6 +23,9 @@ import typing
 import pathlib
 import unicodedata
 from enum import Enum
+from decimal import Decimal
+from dataclasses import asdict, is_dataclass
+from concurrent.futures import ThreadPoolExecutor
 
 from typing import (
     Dict,
@@ -319,3 +320,16 @@ def idem(obj: T, *args, **kwargs) -> T:
     :returns: the parameter ``obj`` unchanged.
     """
     return obj
+
+
+TPE = ThreadPoolExecutor(max_workers=os.cpu_count())
+
+
+def set_tpe(tpe: ThreadPoolExecutor):
+    global TPE
+    TPE = tpe
+
+
+def get_tpe() -> ThreadPoolExecutor:
+    global TPE
+    return TPE

--- a/openlane/container.py
+++ b/openlane/container.py
@@ -21,7 +21,7 @@ import requests
 import subprocess
 from typing import List, Sequence, Optional, Union, Tuple
 
-from .logging import err, info, print, warn
+from .logging import err, info, warn
 from .env_info import OSInfo
 
 CONTAINER_ENGINE = os.getenv("OPENLANE_CONTAINER_ENGINE", "docker")
@@ -100,7 +100,6 @@ def remote_manifest_exists(image: str) -> bool:
         url = f"https://registry.hub.docker.com/v2/repositories/{repo}/tags/{tag}"
     elif registry == "ghcr.io":
         url = f"https://ghcr.io/v2/{repo}/manifests/{tag}"
-        print(url)
     else:
         err(f"Unknown registry '{registry}'.")
         return False

--- a/openlane/flows/flow.py
+++ b/openlane/flows/flow.py
@@ -18,7 +18,7 @@ import glob
 import datetime
 import textwrap
 from abc import abstractmethod
-from concurrent.futures import Future, ThreadPoolExecutor
+from concurrent.futures import Future
 from typing import (
     List,
     Sequence,
@@ -49,7 +49,7 @@ from ..state import State
 from ..steps import Step
 from ..utils import Toolbox
 from ..logging import console, info, verbose, warn
-from ..common import mkdirp, internal, final, slugify
+from ..common import get_tpe, mkdirp, internal, final, slugify
 
 
 class FlowException(RuntimeError):
@@ -144,8 +144,6 @@ class Flow(Step._FlowType):
         config_override_strings: Optional[Sequence[str]] = None,
     ):
         self.name = name or self.__class__.__name__
-
-        self.tpe: ThreadPoolExecutor = ThreadPoolExecutor()
 
         self.Steps = self.Steps.copy()  # Break global reference
         self._reset_private_state_variables()
@@ -377,7 +375,7 @@ class Flow(Step._FlowType):
 
         kwargs["toolbox"] = self.toolbox
 
-        return self.tpe.submit(step.start, *args, **kwargs)
+        return get_tpe().submit(step.start, *args, **kwargs)
 
     @internal
     def set_max_stage_count(self, count: int):

--- a/openlane/flows/sequential.py
+++ b/openlane/flows/sequential.py
@@ -14,7 +14,6 @@
 from __future__ import annotations
 
 import os
-import subprocess
 from typing import List, Tuple, Optional, Type, Dict, Union
 
 from .flow import Flow, FlowException, FlowError
@@ -175,7 +174,7 @@ class SequentialFlow(Flow):
                     raise FlowException(str(e))
                 except DeferredStepError as e:
                     deferred_errors.append(str(e))
-                except (StepError, subprocess.CalledProcessError) as e:
+                except StepError as e:
                     raise FlowError(str(e))
 
             self.end_stage(increment_ordinal=increment_ordinal)

--- a/openlane/logging.py
+++ b/openlane/logging.py
@@ -65,17 +65,6 @@ def get_log_level() -> int:
     return logging.getLogger().getEffectiveLevel()
 
 
-def print(*args, **kwargs):
-    """
-    Prints to the terminal without formatting.
-
-    See the Rich API for more info: https://rich.readthedocs.io/en/stable/reference/console.html#rich.console.Console.print
-    """
-    if get_log_level() > LogLevels.INFO:
-        return
-    console.print(*args, **kwargs, crop=False, style=None)
-
-
 def verbose(*args, **kwargs):
     """
     Prints to the terminal with automatic rich formatting.

--- a/openlane/scripts/openroad/drt.tcl
+++ b/openlane/scripts/openroad/drt.tcl
@@ -14,7 +14,7 @@
 source $::env(SCRIPTS_DIR)/openroad/common/io.tcl
 read_current_odb
 
-set_thread_count $::env(ROUTING_CORES)
+set_thread_count $::env(DRT_THREADS)
 
 set min_layer $::env(RT_MIN_LAYER)
 if { [info exists ::env(DRT_MIN_LAYER)] } {

--- a/openlane/steps/tclstep.py
+++ b/openlane/steps/tclstep.py
@@ -463,8 +463,12 @@ class TclStep(Step):
                 env=env,
                 **kwargs,
             )
-        except subprocess.CalledProcessError:
-            if self.reproducibles_allowed:
+        except subprocess.CalledProcessError as e:
+            if (
+                e.returncode is not None
+                and e.returncode > 0
+                and self.reproducibles_allowed
+            ):
                 reproducible_folder = create_reproducible(
                     self.config["DESIGN_DIR"],
                     self.step_dir,


### PR DESCRIPTION

* Added a commandline option `-j/--jobs` to add a maximum cap on subprocesses.
* Added a global ThreadPoolExecutor object for all subprocesses to `common`.
  * Accessible for external scripts and plugins via `openlane.get_tpe` and `openlane.set_tpe`
* Folded `--list-plugins` into `--version`
* Renamed `ROUTING_CORES` to `ROUTING_THREADS`
* Removed `RCX_CORES`, step now uses global ThreadPoolExecutor