### PR TITLE
Fix Max Transition Setting

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,9 @@
+# 2.0.0-a37
+
+* Added `MAX_TRANSITION_CONSTRAINT` to `base.sdc` (if set)
+* Added `MAX_TRANSITION_CONSTRAINT` -> `SYNTH_MAX_TRAN` translation behavior in `base.sdc`
+* Removed attempt(s) to calculate a default value for `MAX_TRANSITION_CONSTRAINT` in `all.tcl`, `openroad/cts.tcl` and `yosys/synth.tcl`
+
 # 2.0.0-a36
 
 * Added a commandline option `-j/--jobs` to add a maximum cap on subprocesses.

--- a/designs/xtea/src/xtea.sdc
+++ b/designs/xtea/src/xtea.sdc
@@ -6,6 +6,9 @@ puts "\[INFO\] Setting output delay to: $output_delay_value"
 puts "\[INFO\] Setting input delay to: $input_delay_value"
 
 set_max_fanout $::env(SYNTH_MAX_FANOUT) [current_design]
+if { [info exists ::env(SYNTH_MAX_TRAN)] } {
+    set_max_transition $::env(SYNTH_MAX_TRAN) [current_design]
+}
 
 set clk_indx [lsearch [all_inputs] [get_port $::env(CLOCK_PORT)]]
 set all_inputs_wo_clk [lreplace [all_inputs] $clk_indx $clk_indx]

--- a/openlane/__version__.py
+++ b/openlane/__version__.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-__version__ = "2.0.0a36"
+__version__ = "2.0.0a37"
 
 if __name__ == "__main__":
     print(__version__, end="")

--- a/openlane/scripts/base.sdc
+++ b/openlane/scripts/base.sdc
@@ -22,6 +22,9 @@ puts "\[INFO] Setting output delay to: $output_delay_value"
 puts "\[INFO] Setting input delay to: $input_delay_value"
 
 set_max_fanout $::env(MAX_FANOUT_CONSTRAINT) [current_design]
+if { [info exists ::env(MAX_TRANSITION_CONSTRAINT)] } {
+    set_max_transition $::env(MAX_TRANSITION_CONSTRAINT) [current_design]
+}
 
 set clk_input [get_port $clock_port]
 set clk_indx [lsearch [all_inputs] $clk_input]

--- a/openlane/scripts/openroad/common/io.tcl
+++ b/openlane/scripts/openroad/common/io.tcl
@@ -39,6 +39,7 @@ proc read_current_sdc {} {
     set ::env(SYNTH_MAX_FANOUT) $::env(MAX_FANOUT_CONSTRAINT)
     set ::env(SYNTH_CLOCK_UNCERTAINTY) $::env(CLOCK_UNCERTAINTY_CONSTRAINT)
     set ::env(SYNTH_CLOCK_TRANSITION) $::env(CLOCK_TRANSITION_CONSTRAINT)
+    set ::env(SYNTH_MAX_TRAN) $::env(MAX_TRANSITION_CONSTRAINT)
 
     if { [env_var_used $::env(CURRENT_SDC) SYNTH_DRIVING_CELL_PIN] == 1 } {
         set ::env(SYNTH_DRIVING_CELL_PIN) [lindex [split $::env(SYNTH_DRIVING_CELL) "/"] 1]

--- a/openlane/scripts/openroad/common/io.tcl
+++ b/openlane/scripts/openroad/common/io.tcl
@@ -39,7 +39,9 @@ proc read_current_sdc {} {
     set ::env(SYNTH_MAX_FANOUT) $::env(MAX_FANOUT_CONSTRAINT)
     set ::env(SYNTH_CLOCK_UNCERTAINTY) $::env(CLOCK_UNCERTAINTY_CONSTRAINT)
     set ::env(SYNTH_CLOCK_TRANSITION) $::env(CLOCK_TRANSITION_CONSTRAINT)
-    set ::env(SYNTH_MAX_TRAN) $::env(MAX_TRANSITION_CONSTRAINT)
+    if { [info exists ::env(MAX_TRANSITION_CONSTRAINT)] } {
+        set ::env(SYNTH_MAX_TRAN) $::env(MAX_TRANSITION_CONSTRAINT)
+    }
 
     if { [env_var_used $::env(CURRENT_SDC) SYNTH_DRIVING_CELL_PIN] == 1 } {
         set ::env(SYNTH_DRIVING_CELL_PIN) [lindex [split $::env(SYNTH_DRIVING_CELL) "/"] 1]

--- a/openlane/scripts/openroad/cts.tcl
+++ b/openlane/scripts/openroad/cts.tcl
@@ -14,14 +14,6 @@
 source $::env(SCRIPTS_DIR)/openroad/common/io.tcl
 read_current_odb
 
-if {![info exist ::env(MAX_TRANSITION_CONSTRAINT)]} {
-    set ::env(MAX_TRANSITION_CONSTRAINT) [expr {0.1 * $::env(CLOCK_PERIOD)}]
-} else {
-    set ::env(MAX_TRANSITION_CONSTRAINT) [expr {$::env(MAX_TRANSITION_CONSTRAINT) * 1000}]
-}
-set max_slew [expr {$::env(MAX_TRANSITION_CONSTRAINT) * 1e-9}]; # must convert to seconds
-set max_cap [expr {$::env(CTS_MAX_CAP) * 1e-12}]; # must convert to farad
-
 # set rc values
 source $::env(SCRIPTS_DIR)/openroad/common/set_rc.tcl
 estimate_parasitics -placement
@@ -31,9 +23,12 @@ estimate_parasitics -placement
 repair_clock_inverters
 
 puts "\[INFO\] Configuring cts characterization…"
-configure_cts_characterization\
-    -max_slew $max_slew\
-    -max_cap $max_cap
+set cts_characterization_args [list]
+lappend -max_cap [expr {$::env(CTS_MAX_CAP) * 1e-12}]; # pF -> F
+if { [info exists ::env(MAX_FANOUT_CONSTRAINT)] } {
+    lappend -max_slew [expr {$::env(MAX_FANOUT_CONSTRAINT) * 1e-9}]; # ns -> S
+}
+configure_cts_characterization {*}$cts_characterization_args
 
 puts "\[INFO]: Performing clock tree synthesis…"
 puts "\[INFO]: Looking for the following net(s): $::env(CLOCK_NET)"

--- a/openlane/scripts/yosys/synthesize.tcl
+++ b/openlane/scripts/yosys/synthesize.tcl
@@ -36,12 +36,11 @@ foreach lib $dfflib {
 read_deps
 
 set max_FO $::env(MAX_FANOUT_CONSTRAINT)
-if {![info exist ::env(MAX_TRANSITION_CONSTRAINT)]} {
-    set ::env(MAX_TRANSITION_CONSTRAINT) [expr {0.1 * $::env(CLOCK_PERIOD)}]
+set max_TR 0
+if { [info exist ::env(MAX_TRANSITION_CONSTRAINT)]} {
+    set max_TR [expr {$::env(MAX_TRANSITION_CONSTRAINT) * 1000}]; # ns -> ps
 }
-# conversions from µs to ns
-set max_TR [expr {$::env(MAX_TRANSITION_CONSTRAINT) * 1000}]
-set clock_period [expr {$::env(CLOCK_PERIOD)*1000}]
+set clock_period [expr {$::env(CLOCK_PERIOD) * 1000}]; # ns -> ps
 
 # Mapping parameters
 set A_factor  0.00
@@ -93,7 +92,11 @@ set abc_retime_dly    	"retime,-D,{D},-M,6"
 set abc_map_new_area  	"amap,-m,-Q,0.1,-F,20,-A,20,-C,5000"
 
 if { $::env(SYNTH_BUFFERING) == 1 } {
-    set abc_fine_tune		"buffer,-N,${max_FO},-S,${max_TR};upsize,{D};dnsize,{D}"
+    set max_tr_arg ""
+    if { $max_TR != 0 } {
+        set max_tr_arg ",-S,${max_TR}"
+    }
+    set abc_fine_tune		"buffer,-N,${max_FO}${max_tr_arg};upsize,{D};dnsize,{D}"
 } elseif {$::env(SYNTH_SIZING)} {
     set abc_fine_tune       "upsize,{D};dnsize,{D}"
 } else {


### PR DESCRIPTION
* Added `MAX_TRANSITION_CONSTRAINT` to `base.sdc` (if set)
* Added `MAX_TRANSITION_CONSTRAINT` -> `SYNTH_MAX_TRAN` translation behavior in `base.sdc`
* Removed attempt(s) to calculate a default value for `MAX_TRANSITION_CONSTRAINT` in `all.tcl`, `openroad/cts.tcl` and `yosys/synth.tcl`