### PR TITLE
STA Metrics, Aggregation and Summary Table

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,13 @@
+# 2.0.0-a39
+* Added mechanism for subprocesses to write metrics via stdout, `%OL_METRIC{,_I,_F}`, used for OpenSTA
+* Added violation summary table to post-PNR STA
+* Reworked multi-corner STA: now run across N processes with the step being responsible for aggregation
+* Made handling `Infinity` metrics more robust
+* Fixed names of various metrics to abide with conventions:
+  * `magic__drc_errors` -> `magic__drc_error__count`
+  * `magic__illegal__overlaps` -> `magic__illegal_overlap__count`
+* Removed splash messages from OpenROAD, OpenSTA
+
 # 2.0.0-a38
 
 * Added full test-suite added to CI

--- a/openlane/__version__.py
+++ b/openlane/__version__.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-__version__ = "2.0.0a38"
+__version__ = "2.0.0a39"
 
 if __name__ == "__main__":
     print(__version__, end="")

--- a/openlane/common.py
+++ b/openlane/common.py
@@ -333,3 +333,19 @@ def set_tpe(tpe: ThreadPoolExecutor):
 def get_tpe() -> ThreadPoolExecutor:
     global TPE
     return TPE
+
+
+## Metrics
+
+modifier_rx = re.compile(r"([\w\-]+)\:([\w\-]+)$")
+
+
+def parse_metric_modifiers(metric_name: str) -> Tuple[str, Dict[str, str]]:
+    mn_mut = metric_name.split("__")
+    modifiers = {}
+    i = len(mn_mut) - 1
+    while match := modifier_rx.match(mn_mut[i]):
+        mn_mut.pop()
+        modifiers[match[1]] = match[2]
+        i = i - 1
+    return "__".join(mn_mut), modifiers

--- a/openlane/scripts/odbpy/reader.py
+++ b/openlane/scripts/odbpy/reader.py
@@ -39,7 +39,10 @@ import rich
 from rich.table import Table
 from openlane.state.design_format import DesignFormat, DesignFormatObject
 
-click  # Re-export now that the environment actually works properly
+# Re-export now that the environment actually works properly
+rich
+click
+Table
 
 write_fn: Dict[DesignFormat, Callable] = {
     DesignFormat.DEF: lambda reader, file: odb.write_def(reader.block, file),

--- a/openlane/scripts/openroad/common/io.tcl
+++ b/openlane/scripts/openroad/common/io.tcl
@@ -321,3 +321,60 @@ proc write_libs {} {
         }
     }
 }
+
+proc max {a b} {
+    if { $a > $b } {
+        return $a
+    } else {
+        return $b
+    }
+}
+
+set ::metric_count 0
+set ::metrics_file ""
+if { [info exists ::env(OPENSTA)] && $::env(OPENSTA) } {
+    proc start_metrics_file {args} {
+        set ::metrics_file [open $::env(STEP_DIR)/metrics.json "w"]
+        puts $::metrics_file "\{"
+    }
+    proc write_metric_num {metric value} {
+        if { $::metric_count > 0 } {
+            puts $::metrics_file ","
+        }
+        if { "$value" == "INF" } {
+            set value 1e30
+        }
+        puts $::metrics_file "\"$metric\": $value"
+        incr ::metric_count
+    }
+    proc write_metric_int {metric value} {
+        write_metric_num $metric $value
+    }
+    proc write_metric_str {metric value} {
+        if { $::metric_count > 0 } {
+            puts $::metrics_file ","
+        }
+        puts $::metrics_file "\"$metric\": \"$value\""
+        incr ::metric_count
+    }
+    proc end_metrics_file {args} {
+        puts $::metrics_file "\}"
+        close $::metrics_file
+        set ::metrics_file ""
+    }
+} else {
+    proc start_metrics_file {} {}
+    proc write_metric_str {metric value} {
+        puts "Writing metric $metric: $value"
+        utl::metric $metric $value
+    }
+    proc write_metric_int {metric value} {
+        puts "Writing metric $metric: $value"
+        utl::metric_int $metric $value
+    }
+    proc write_metric_num {metric value} {
+        puts "Writing metric $metric: $value"
+        utl::metric_float $metric $value
+    }
+    proc end_metrics_file {} {}
+}

--- a/openlane/scripts/openroad/common/io.tcl
+++ b/openlane/scripts/openroad/common/io.tcl
@@ -314,7 +314,13 @@ set ::metric_count 0
 set ::metrics_file ""
 if { [info exists ::env(OPENSTA)] && $::env(OPENSTA) } {
     proc write_metric_num {metric value} {
-        puts "%OL_METRIC_F $metric $value"
+        if { $value == 1e30 } {
+            write_metric_str $metric Infinity
+        } elseif { $value == -1e30 } {
+            write_metric_str $metric -Infinity
+        } else {
+            puts "%OL_METRIC_F $metric $value"
+        }
     }
     proc write_metric_int {metric value} {
         puts "%OL_METRIC_I $metric $value"

--- a/openlane/scripts/openroad/floorplan.tcl
+++ b/openlane/scripts/openroad/floorplan.tcl
@@ -96,7 +96,7 @@ puts "\[INFO] Floorplanned on a core area of $::env(CORE_AREA) (µm)."
 
 source $::env(TRACKS_INFO_FILE_PROCESSED)
 
-utl::metric "design__die__bbox"  $::env(DIE_AREA)
-utl::metric "design__core__bbox" $::env(CORE_AREA)
+write_metric_str "design__die__bbox"  $::env(DIE_AREA)
+write_metric_str "design__core__bbox" $::env(CORE_AREA)
 
 write_views

--- a/openlane/scripts/openroad/rcx.tcl
+++ b/openlane/scripts/openroad/rcx.tcl
@@ -14,7 +14,6 @@
 source $::env(SCRIPTS_DIR)/openroad/common/io.tcl
 read_lefs "RCX_LEF"
 read_def $::env(CURRENT_DEF)
-read_timing_info
 
 
 set_propagated_clock [all_clocks]

--- a/openlane/scripts/openroad/sta/corner.tcl
+++ b/openlane/scripts/openroad/sta/corner.tcl
@@ -1,0 +1,297 @@
+# Copyright 2020-2023 Efabless Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file supports one defined corner per-process.
+# Any more defined corners will be ignored.
+# Aggregation is left to the OpenLane step.
+
+
+source $::env(SCRIPTS_DIR)/openroad/common/io.tcl
+
+set_cmd_units\
+    -time ns\
+    -capacitance pF\
+    -current mA\
+    -voltage V\
+    -resistance kOhm\
+    -distance um
+
+set sta_report_default_digits 6
+
+if { ![info exists ::env(OPENSTA)] || !$::env(OPENSTA) } {
+    read_current_odb
+
+    # Internal API- brittle
+    if { [grt::have_routes] } {
+        estimate_parasitics -global_routing
+    } elseif { [rsz::check_corner_wire_cap] } {
+        estimate_parasitics -placement
+    }
+} else {
+    read_timing_info
+}
+read_spefs
+
+set_propagated_clock [all_clocks]
+
+set corner [lindex [sta::corners] 0]
+sta::set_cmd_corner $corner
+
+set clocks [sta::sort_by_name [sta::all_clocks]]
+
+puts "%OL_CREATE_REPORT min.rpt"
+puts "\n==========================================================================="
+puts "report_checks -path_delay min (Hold)"
+puts "============================================================================"
+puts "======================= [$corner name] Corner ===================================\n"
+report_checks -sort_by_slack -path_delay min -fields {slew cap input nets fanout} -format full_clock_expanded -group_count 1000 -corner [$corner name]
+puts ""
+puts "%OL_END_REPORT"
+
+
+puts "%OL_CREATE_REPORT max.rpt"
+puts "\n==========================================================================="
+puts "report_checks -path_delay max (Setup)"
+puts "============================================================================"
+puts "======================= [$corner name] Corner ===================================\n"
+report_checks -sort_by_slack -path_delay max -fields {slew cap input nets fanout} -format full_clock_expanded -group_count 1000 -corner [$corner name]
+puts ""
+puts "%OL_END_REPORT"
+
+
+puts "%OL_CREATE_REPORT checks.rpt"
+puts "\n==========================================================================="
+puts "report_checks -unconstrained"
+puts "==========================================================================="
+puts "======================= [$corner name] Corner ===================================\n"
+report_checks -unconstrained -fields {slew cap input nets fanout} -format full_clock_expanded -corner [$corner name]
+puts ""
+
+
+puts "\n==========================================================================="
+puts "report_checks --slack_max -0.01"
+puts "============================================================================"
+puts "======================= [$corner name] Corner ===================================\n"
+report_checks -slack_max -0.01 -fields {slew cap input nets fanout} -format full_clock_expanded -corner [$corner name]
+puts ""
+
+puts "\n==========================================================================="
+puts " report_check_types -max_slew -max_cap -max_fanout -violators"
+puts "============================================================================"
+puts "======================= [$corner name] Corner ===================================\n"
+report_check_types -max_slew -max_capacitance -max_fanout -violators -corner [$corner name]
+puts ""
+
+puts "\n==========================================================================="
+puts "report_parasitic_annotation -report_unannotated"
+puts "============================================================================"
+report_parasitic_annotation -report_unannotated
+
+puts "\n==========================================================================="
+puts "max slew violation count [sta::max_slew_violation_count]"
+write_metric_int "clock__max_slew_violation__count__corner:[$corner name]" [sta::max_slew_violation_count]
+puts "max fanout violation count [sta::max_fanout_violation_count]"
+write_metric_int "design__max_fanout_violation__count__corner:[$corner name]" [sta::max_fanout_violation_count]
+puts "max cap violation count [sta::max_capacitance_violation_count]"
+write_metric_int "design__max_cap_violation__count__corner:[$corner name]" [sta::max_capacitance_violation_count]
+puts "============================================================================"
+
+puts "\n==========================================================================="
+puts "check_setup -verbose -unconstrained_endpoints -multiple_clock -no_clock -no_input_delay -loops -generated_clocks"
+puts "==========================================================================="
+check_setup -verbose -unconstrained_endpoints -multiple_clock -no_clock -no_input_delay -loops -generated_clocks
+puts "%OL_END_REPORT"
+
+
+
+puts "%OL_CREATE_REPORT power.rpt"
+puts "\n==========================================================================="
+puts " report_power"
+puts "============================================================================"
+puts "======================= [$corner name] Corner ===================================\n"
+report_power -corner [$corner name]
+puts ""
+puts "%OL_END_REPORT"
+
+
+puts "%OL_CREATE_REPORT skew.min.rpt"
+puts "\n==========================================================================="
+puts "Clock Skew (Hold)"
+puts "============================================================================"
+set skew_corner [sta::format_time [sta::worst_clk_skew_cmd "min"] $sta_report_default_digits]
+write_metric_num "clock__skew__worst_hold__corner:[$corner name]" $skew_corner
+
+puts "======================= [$corner name] Corner ===================================\n"
+report_clock_skew -corner [$corner name] -hold
+
+puts "%OL_END_REPORT"
+
+puts "%OL_CREATE_REPORT skew.max.rpt"
+puts "\n==========================================================================="
+puts "Clock Skew (Setup)"
+puts "============================================================================"
+set skew_corner [sta::format_time [sta::worst_clk_skew_cmd "max"] $sta_report_default_digits]
+
+write_metric_num "clock__skew__worst_setup__corner:[$corner name]" $skew_corner
+
+puts "======================= [$corner name] Corner ===================================\n"
+report_clock_skew -corner [$corner name] -setup
+
+puts "%OL_END_REPORT"
+
+puts "%OL_CREATE_REPORT ws.min.rpt"
+puts "\n==========================================================================="
+puts "Worst Slack (Hold)"
+puts "============================================================================"
+set ws [sta::format_time [sta::worst_slack_corner $corner "min"] $sta_report_default_digits]
+write_metric_num "timing__hold__ws__corner:[$corner name]" $ws
+puts "[$corner name]: $ws"
+puts "%OL_END_REPORT"
+
+puts "%OL_CREATE_REPORT ws.max.rpt"
+puts "\n==========================================================================="
+puts "Worst Slack (Setup)"
+puts "============================================================================"
+
+set ws [sta::format_time [sta::worst_slack_corner $corner "max"] $sta_report_default_digits]
+write_metric_num "timing__setup__ws__corner:[$corner name]" $ws
+puts "[$corner name]: $ws"
+puts "%OL_END_REPORT"
+
+puts "%OL_CREATE_REPORT tns.min.rpt"
+puts "\n==========================================================================="
+puts "Total Negative Slack (Hold)"
+puts "============================================================================"
+
+set tns [sta::format_time [sta::total_negative_slack_corner_cmd $corner "min"] $sta_report_default_digits]
+write_metric_num "timing__hold__tns__corner:[$corner name]" $tns
+puts "[$corner name]: $tns"
+puts "%OL_END_REPORT"
+
+puts "%OL_CREATE_REPORT tns.max.rpt"
+puts "\n==========================================================================="
+puts "Total Negative Slack (Setup)"
+puts "============================================================================"
+set tns_design 0
+foreach corner [sta::corners] {
+    set tns [sta::format_time [sta::total_negative_slack_corner_cmd $corner "max"] $sta_report_default_digits]
+    write_metric_num "timing__setup__tns__corner:[$corner name]" $tns
+    puts "[$corner name]: $tns"
+}
+puts "%OL_END_REPORT"
+
+puts "%OL_CREATE_REPORT wns.min.rpt"
+puts "\n==========================================================================="
+puts "Worst Negative Slack (Hold)"
+puts "============================================================================"
+
+set ws [sta::format_time [sta::worst_slack_corner $corner "min"] $sta_report_default_digits]
+set wns 0
+if { $ws < 0 } {
+    set wns $ws
+}
+write_metric_num "timing__hold__wns__corner:[$corner name]" $wns
+puts "[$corner name]: $wns"
+puts "%OL_END_REPORT"
+
+puts "%OL_CREATE_REPORT wns.max.rpt"
+puts "\n==========================================================================="
+puts "Worst Negative Slack (Setup)"
+puts "============================================================================"
+
+set ws [sta::format_time [sta::worst_slack_corner $corner "max"] $sta_report_default_digits]
+set wns 0.0
+if { $ws < 0 } {
+    set wns $ws
+}
+write_metric_num "timing__setup__wns__corner:[$corner name]" $wns
+puts "[$corner name]: $wns"
+puts "%OL_END_REPORT"
+
+proc check_if_terminal {pin_object} {
+    set net [get_nets -of_object $pin_object]
+    if { "$net" == "NULL" } {
+        return 1
+    }
+    return 0
+}
+
+puts "%OL_CREATE_REPORT violator_list.rpt"
+puts "\n==========================================================================="
+puts "Violator List"
+puts "============================================================================"
+
+set total_hold_vios 0
+set r2r_hold_vios 0
+set total_setup_vios 0
+set r2r_setup_vios 0
+
+set hold_timing_paths [find_timing_paths -unique_paths_to_endpoint -path_delay min -sort_by_slack -group_count 999999999 -slack_max 0]
+foreach path $hold_timing_paths {
+    set from "reg"
+    set to "reg"
+
+    set start_pin [get_property $path startpoint]
+    set end_pin [get_property $path endpoint]
+
+    if { [check_if_terminal $start_pin] } {
+        set from "in"
+    }
+    if { [check_if_terminal $end_pin] } {
+        set to "out"
+    }
+    set kind "$from-$to"
+
+    incr total_hold_vios
+    if { "$kind" == "reg-reg" } {
+        incr r2r_hold_vios
+    }
+
+    puts "\[hold $kind] [get_property $start_pin full_name] -> [get_property $end_pin full_name] : [get_property $path slack]"
+}
+
+set setup_timing_paths [find_timing_paths -unique_paths_to_endpoint -path_delay max -sort_by_slack -group_count 999999999 -slack_max 0]
+foreach path $setup_timing_paths {
+    set from "reg"
+    set to "reg"
+
+    set start_pin [get_property $path startpoint]
+    set end_pin [get_property $path endpoint]
+
+    if { [check_if_terminal $start_pin] } {
+        set from "in"
+    }
+    if { [check_if_terminal $end_pin] } {
+        set to "out"
+    }
+
+    set kind "$from-$to"
+
+    incr total_setup_vios
+    if { "$kind" == "reg-reg" } {
+        incr r2r_setup_vios
+    }
+
+    puts "\[setup $kind] [get_property $start_pin full_name] -> [get_property $end_pin full_name] : [get_property $path slack]"
+}
+
+write_metric_int "timing__hold_vio__count__corner:[$corner name]" $total_hold_vios
+write_metric_int "timing__hold_r2r_vio__count__corner:[$corner name]" $r2r_hold_vios
+write_metric_int "timing__setup_vio__count__corner:[$corner name]" $total_setup_vios
+write_metric_int "timing__setup_r2r_vio__count__corner:[$corner name]" $r2r_setup_vios
+puts "%OL_END_REPORT"
+
+
+write_sdfs
+write_libs

--- a/openlane/scripts/openroad/sta/multi_corner.tcl
+++ b/openlane/scripts/openroad/sta/multi_corner.tcl
@@ -23,8 +23,6 @@ set_cmd_units\
 
 set sta_report_default_digits 6
 
-
-read_timing_info
 if { ![info exists ::env(OPENSTA)] || !$::env(OPENSTA) } {
     read_current_odb
 
@@ -34,12 +32,12 @@ if { ![info exists ::env(OPENSTA)] || !$::env(OPENSTA) } {
     } elseif { [rsz::check_corner_wire_cap] } {
         estimate_parasitics -placement
     }
+} else {
+    read_timing_info
 }
 read_spefs
 
 set_propagated_clock [all_clocks]
-
-start_metrics_file
 
 puts "%OL_CREATE_REPORT min.rpt"
 puts "\n==========================================================================="
@@ -100,12 +98,16 @@ puts "==========================================================================
 report_parasitic_annotation -report_unannotated
 
 puts "\n==========================================================================="
+set corner_postfix ""
+if { [info exists ::env(CURRENT_CORNER_NAME)] } {
+    set corner_postfix "__corner:$::env(CURRENT_CORNER_NAME)"
+}
 puts "max slew violation count [sta::max_slew_violation_count]"
-write_metric_int "clock__max_slew_violation__count" [sta::max_slew_violation_count]
+write_metric_int "clock__max_slew_violation__count$corner_postfix" [sta::max_slew_violation_count]
 puts "max fanout violation count [sta::max_fanout_violation_count]"
-write_metric_int "design__max_fanout_violation__count" [sta::max_fanout_violation_count]
+write_metric_int "design__max_fanout_violation__count$corner_postfix" [sta::max_fanout_violation_count]
 puts "max cap violation count [sta::max_capacitance_violation_count]"
-write_metric_int "design__max_cap_violation__count" [sta::max_capacitance_violation_count]
+write_metric_int "design__max_cap_violation__count$corner_postfix" [sta::max_capacitance_violation_count]
 puts "============================================================================"
 
 puts "\n==========================================================================="
@@ -147,8 +149,10 @@ foreach corner [sta::corners] {
 }
 sta::set_cmd_corner $default_corner
 
-write_metric_num "clock__skew__worst_hold" $skew_design
-puts "worst overall skew: $skew_design"
+if { ![info exists ::env(CURRENT_CORNER_NAME)] } {
+    write_metric_num "clock__skew__worst_hold" $skew_design
+    puts "worst overall skew: $skew_design"
+}
 puts "%OL_END_REPORT"
 
 puts "%OL_CREATE_REPORT skew.max.rpt"
@@ -168,8 +172,10 @@ foreach corner [sta::corners] {
 }
 sta::set_cmd_corner $default_corner
 
-write_metric_num "clock__skew__worst_setup" $skew_design
-puts "worst overall skew: $skew_design"
+if { ![info exists ::env(CURRENT_CORNER_NAME)] } {
+    write_metric_num "clock__skew__worst_setup" $skew_design
+    puts "worst overall skew: $skew_design"
+}
 puts "%OL_END_REPORT"
 
 puts "%OL_CREATE_REPORT ws.min.rpt"
@@ -185,8 +191,10 @@ foreach corner [sta::corners] {
     write_metric_num "timing__hold__ws__corner:[$corner name]" $ws
     puts "[$corner name]: $ws"
 }
-write_metric_num "timing__hold__ws" $ws_design
-puts "design: $ws_design"
+if { ![info exists ::env(CURRENT_CORNER_NAME)] } {
+    write_metric_num "timing__hold__ws" $ws_design
+    puts "design: $ws_design"
+}
 puts "%OL_END_REPORT"
 
 puts "%OL_CREATE_REPORT ws.max.rpt"
@@ -202,8 +210,10 @@ foreach corner [sta::corners] {
     write_metric_num "timing__setup__ws__corner:[$corner name]" $ws
     puts "[$corner name]: $ws"
 }
-write_metric_num "timing__setup__ws" $ws_design
-puts "design: $ws_design"
+if { ![info exists ::env(CURRENT_CORNER_NAME)] } {
+    write_metric_num "timing__setup__ws" $ws_design
+    puts "design: $ws_design"
+}
 puts "%OL_END_REPORT"
 
 puts "%OL_CREATE_REPORT tns.min.rpt"
@@ -217,8 +227,10 @@ foreach corner [sta::corners] {
     write_metric_num "timing__hold__tns__corner:[$corner name]" $tns
     puts "[$corner name]: $tns"
 }
-write_metric_num "timing__hold__tns" $tns_design
-puts "design: $tns_design"
+if { ![info exists ::env(CURRENT_CORNER_NAME)] } {
+    write_metric_num "timing__hold__tns" $tns_design
+    puts "design: $tns_design"
+}
 puts "%OL_END_REPORT"
 
 puts "%OL_CREATE_REPORT tns.max.rpt"
@@ -232,8 +244,10 @@ foreach corner [sta::corners] {
     write_metric_num "timing__setup__tns__corner:[$corner name]" $tns
     puts "[$corner name]: $tns"
 }
-write_metric_num "timing__setup__tns" $tns_design
-puts "design: $tns_design"
+if { ![info exists ::env(CURRENT_CORNER_NAME)] } {
+    write_metric_num "timing__setup__tns" $tns_design
+    puts "design: $tns_design"
+}
 puts "%OL_END_REPORT"
 
 puts "%OL_CREATE_REPORT wns.min.rpt"
@@ -253,8 +267,10 @@ foreach corner [sta::corners] {
     write_metric_num "timing__hold__wns__corner:[$corner name]" $wns
     puts "[$corner name]: $wns"
 }
-write_metric_num "timing__hold__wns" $wns_design
-puts "design: $wns_design"
+if { ![info exists ::env(CURRENT_CORNER_NAME)] } {
+    write_metric_num "timing__hold__wns" $wns_design
+    puts "design: $wns_design"
+}
 puts "%OL_END_REPORT"
 
 puts "%OL_CREATE_REPORT wns.max.rpt"
@@ -274,11 +290,11 @@ foreach corner [sta::corners] {
     write_metric_num "timing__setup__wns__corner:[$corner name]" $wns
     puts "[$corner name]: $wns"
 }
-write_metric_num "timing__setup__wns" $wns_design
-puts "design: $wns_design"
+if { ![info exists ::env(CURRENT_CORNER_NAME)] } {
+    write_metric_num "timing__setup__wns" $wns_design
+    puts "design: $wns_design"
+}
 puts "%OL_END_REPORT"
-
-end_metrics_file
 
 write_sdfs
 write_libs

--- a/openlane/scripts/openroad/sta/multi_corner.tcl.bk
+++ b/openlane/scripts/openroad/sta/multi_corner.tcl.bk
@@ -11,6 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+# This file supports multiple defined corners per-process.
+# It should not be used and is left as a reference.
+
 source $::env(SCRIPTS_DIR)/openroad/common/io.tcl
 
 set_cmd_units\

--- a/openlane/steps/checker.py
+++ b/openlane/steps/checker.py
@@ -175,7 +175,7 @@ class MagicDRC(MetricChecker):
     ]
 
     def get_metric_name(self) -> str:
-        return "magic__drc_errors"
+        return "magic__drc_error__count"
 
     def get_metric_description(self) -> str:
         return "Magic DRC errors"
@@ -198,7 +198,7 @@ class IllegalOverlap(MetricChecker):
     ]
 
     def get_metric_name(self) -> str:
-        return "magic__illegal__overlaps"
+        return "magic__illegal_overlap__count"
 
     def get_metric_description(self) -> str:
         return "Magic Illegal Overlap errors"

--- a/openlane/steps/magic.py
+++ b/openlane/steps/magic.py
@@ -203,7 +203,7 @@ class DRC(MagicStep):
 
     This also converts the results to a KLayout database, which can be loaded.
 
-    The metrics will be updated with ``magic__drc_errors``. You can use
+    The metrics will be updated with ``magic__drc_error__count``. You can use
     `the relevant checker <#Checker.MagicDRC>`_ to quit if that number is
     nonzero.
     """
@@ -254,7 +254,7 @@ class DRC(MagicStep):
         klayout_db_path = os.path.join(reports_dir, "drc.klayout.xml")
         drc.to_klayout_xml(open(klayout_db_path, "wb"))
 
-        metrics_updates["magic__drc_errors"] = bbox_count
+        metrics_updates["magic__drc_error__count"] = bbox_count
 
         return views_updates, metrics_updates
 
@@ -265,7 +265,7 @@ class SpiceExtraction(MagicStep):
     Extracts a SPICE netlist from the GDSII stream. Used in Layout vs. Schematic
     checks.
 
-    Also, the metrics will be updated with ``magic__illegal__overlaps``. You can use
+    Also, the metrics will be updated with ``magic__illegal_overlap__count``. You can use
     `the relevant checker <#Checker.IllegalOverlap>`_ to quit if that number is
     nonzero.
     """
@@ -301,7 +301,7 @@ class SpiceExtraction(MagicStep):
 
         feedback_path = os.path.join(self.step_dir, "feedback.txt")
         feedback_string = open(feedback_path, encoding="utf8").read()
-        metrics_updates["magic__illegal__overlaps"] = feedback_string.count(
+        metrics_updates["magic__illegal_overlap__count"] = feedback_string.count(
             "Illegal overlap"
         )
 

--- a/openlane/steps/odb.py
+++ b/openlane/steps/odb.py
@@ -95,6 +95,7 @@ class OdbpyStep(Step):
             [
                 "openroad",
                 "-exit",
+                "-no_splash",
                 "-metrics",
                 metrics_path,
                 "-python",

--- a/openlane/steps/odb.py
+++ b/openlane/steps/odb.py
@@ -13,9 +13,10 @@
 # limitations under the License.
 import os
 import re
-import shutil
 import sys
 import json
+import shutil
+from math import inf
 from decimal import Decimal
 from functools import reduce
 from abc import abstractmethod
@@ -64,9 +65,13 @@ class OdbpyStep(Step):
         metrics_path = os.path.join(self.step_dir, "or_metrics_out.json")
         metrics_updates: MetricsUpdate = generated_metrics
         if os.path.exists(metrics_path):
-            metrics_str = open(metrics_path).read()
-            metrics_str = inf_rx.sub(lambda m: f"{m[1] or ''}\"Infinity\"", metrics_str)
-            metrics_updates.update(json.loads(metrics_str))
+            or_metrics_out = json.loads(open(metrics_path).read())
+            for key, value in or_metrics_out.items():
+                if value == "Infinity":
+                    or_metrics_out[key] = inf
+                elif value == "-Infinity":
+                    or_metrics_out[key] = -inf
+            metrics_updates.update(or_metrics_out)
 
         views_updates: ViewsUpdate = {}
         for output in [DesignFormat.ODB, DesignFormat.DEF]:
@@ -369,8 +374,6 @@ class DiodesOnPorts(OdbpyStep):
         cell, pin = self.config["DIODE_CELL"].split("/")
 
         return super().get_command() + [
-            "--threshold",
-            "Infinity",
             "--diode-cell",
             cell,
             "--diode-pin",

--- a/openlane/steps/odb.py
+++ b/openlane/steps/odb.py
@@ -55,18 +55,18 @@ class OdbpyStep(Step):
         env["OPENLANE_ROOT"] = get_openlane_root()
         env["ODB_PYTHONPATH"] = ":".join(sys.path)
 
-        self.run_subprocess(
+        generated_metrics = self.run_subprocess(
             command,
             env=env,
             **kwargs,
         )
 
         metrics_path = os.path.join(self.step_dir, "or_metrics_out.json")
-        metrics_updates: MetricsUpdate = {}
+        metrics_updates: MetricsUpdate = generated_metrics
         if os.path.exists(metrics_path):
             metrics_str = open(metrics_path).read()
             metrics_str = inf_rx.sub(lambda m: f"{m[1] or ''}\"Infinity\"", metrics_str)
-            metrics_updates = json.loads(metrics_str)
+            metrics_updates.update(json.loads(metrics_str))
 
         views_updates: ViewsUpdate = {}
         for output in [DesignFormat.ODB, DesignFormat.DEF]:

--- a/openlane/steps/openroad.py
+++ b/openlane/steps/openroad.py
@@ -224,7 +224,7 @@ class STAStep(OpenROADStep):
         return None
 
     def get_script_path(self):
-        return os.path.join(get_script_dir(), "openroad", "sta", "multi_corner.tcl")
+        return os.path.join(get_script_dir(), "openroad", "sta", "corner.tcl")
 
 
 @Step.factory.register()

--- a/openlane/steps/tclstep.py
+++ b/openlane/steps/tclstep.py
@@ -457,7 +457,7 @@ class TclStep(Step):
         env = self.prepare_env(env, state_in)
 
         try:
-            self.run_subprocess(
+            generated_metrics = self.run_subprocess(
                 command,
                 env=env,
                 **kwargs,
@@ -490,4 +490,4 @@ class TclStep(Step):
                 continue
             overrides[output] = path
 
-        return overrides, {}
+        return overrides, generated_metrics

--- a/openlane/steps/tclstep.py
+++ b/openlane/steps/tclstep.py
@@ -226,7 +226,6 @@ def create_reproducible(
         for potential_file in full_value.split():
             potential_file_abspath = os.path.abspath(potential_file)
             if potential_file_abspath.startswith(run_path):
-                final_env[key] = ""
                 relative = relpath(potential_file, run_path)
                 final_value = join(".", relative)
                 final_path = join(destination_folder, final_value)

--- a/openlane/utils/toolbox.py
+++ b/openlane/utils/toolbox.py
@@ -20,19 +20,49 @@ import tempfile
 import subprocess
 from enum import IntEnum
 from shutil import which
-from typing import FrozenSet, Mapping, Optional, Tuple, List, Union
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    FrozenSet,
+    Iterable,
+    Mapping,
+    Optional,
+    Tuple,
+    List,
+    Union,
+)
 
 from .memoize import memoize
 
 from ..logging import debug, warn
 from ..config import Config, Macro
 from ..state import DesignFormat, Path
-from ..common import mkdirp, get_script_dir
+from ..common import mkdirp, get_script_dir, parse_metric_modifiers
 
 
 class Toolbox(object):
     def __init__(self, tmp_dir: str) -> None:
         self.tmp_dir = os.path.abspath(tmp_dir)
+
+    def aggregate_metrics(
+        self,
+        input: Dict[str, Any],
+        aggregator_by_metric: Dict[str, Tuple[Any, Callable[[Iterable], Any]]],
+    ) -> Dict[str, Any]:
+        final_values = input.copy()
+        for name, value in input.items():
+            metric_name, modifiers = parse_metric_modifiers(name)
+            if len(modifiers) == 0:
+                # No modifiers = final aggregate, don't double-represent in sums
+                continue
+            entry = aggregator_by_metric.get(metric_name)
+            if entry is None:
+                continue
+            start, aggregator = entry
+            current = final_values.get(metric_name) or start
+            final_values[metric_name] = aggregator([current, value])
+        return final_values
 
     def filter_views(
         self,

--- a/openlane/utils/toolbox.py
+++ b/openlane/utils/toolbox.py
@@ -50,7 +50,7 @@ class Toolbox(object):
         input: Dict[str, Any],
         aggregator_by_metric: Dict[str, Tuple[Any, Callable[[Iterable], Any]]],
     ) -> Dict[str, Any]:
-        final_values = input.copy()
+        aggregated: Dict[str, Any] = {}
         for name, value in input.items():
             metric_name, modifiers = parse_metric_modifiers(name)
             if len(modifiers) == 0:
@@ -60,8 +60,11 @@ class Toolbox(object):
             if entry is None:
                 continue
             start, aggregator = entry
-            current = final_values.get(metric_name) or start
-            final_values[metric_name] = aggregator([current, value])
+            current = aggregated.get(metric_name) or start
+            aggregated[metric_name] = aggregator([current, value])
+
+        final_values = input.copy()
+        final_values.update(aggregated)
         return final_values
 
     def filter_views(


### PR DESCRIPTION
* Added mechanism for subprocesses to write metrics via stdout, `%OL_METRIC{,_I,_F}`, used for OpenSTA
* Added violation summary table to post-PNR STA
* Reworked multi-corner STA: now run across N processes with the step being responsible for aggregation
* Made handling `Infinity` metrics more robust
* Fixed names of various metrics to abide with conventions:
  * `magic__drc_errors` -> `magic__drc_error__count`
  * `magic__illegal__overlaps` -> `magic__illegal_overlap__count`
* Removed splash messages from OpenROAD, OpenSTA

---
Resolves #42 