### PR TITLE
Fix Resizer Step Bug + DRC Report Parsing

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,14 +1,23 @@
+# 2.0.0-a45
+
+* Made Magic DRC report parser more robust, handling multiple rules, etc
+* Updated documentation for various related variables
+* Fixed bug causing PNR-excluded cells being used during resizer-based OpenROAD steps 
+
 # 2.0.0-a44
+
 * Added support for multiple corners during CTS using the `CTS_CORNERS` variable
 * Added support for multiple corners during resizer steps using the `RSZ_CORNERS` variable
 * Internally reworked OpenROAD resizer and CTS steps to share a common base class
 
 # 2.0.0-a43
+
 * Added `io_placer` and `manual_macro_placemnt_test` to CI
 * Fixed `MAGTYPE` for `Magic.WriteLEF`
 * Fixed bug with reading `EXTRA_LEFS` in Magic steps 
 
 # 2.0.0-a42
+
 * Added support for instances to `RSZ_DONT_TOUCH_RX`
 * Added support for `RSZ_DONT_TOUCH_LIST` to resizer steps
 * `inverter` design used to configure the above two
@@ -18,17 +27,20 @@
 * Fixed issue in `usb_cdc_core` masked by aforementioned bug
 
 # 2.0.0-a41
+
 * Updated Magic to `9b131fa`
 * Updated Magic LEF writing script
 * Ensured consistency of Tcl script logging prefixes
 
 # 2.0.0-a40
+
 * Fixed a bug with extracting variables from Tcl config files when the variable
   is already set in the environment
 * Fixed a bug with saving lib and SDF files
 * Fixed `check_antennas.tcl` being mis-named
 
 # 2.0.0-a39
+
 * Added mechanism for subprocesses to write metrics via stdout, `%OL_METRIC{,_I,_F}`, used for OpenSTA
 * Added violation summary table to post-PNR STA
 * Reworked multi-corner STA: now run across N processes with the step being responsible for aggregation

--- a/designs/y_huff/config.json
+++ b/designs/y_huff/config.json
@@ -6,6 +6,7 @@
     "GPL_CELL_PADDING": 4,
     "DPL_CELL_PADDING": 4,
     "FP_CORE_UTIL": 25,
+    "QUIT_ON_SYNTH_CHECKS": false,
     "pdk::sky130*": {
         "FP_SIZING": "absolute",
         "DIE_AREA": "0 0 700 700",

--- a/openlane/__version__.py
+++ b/openlane/__version__.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-__version__ = "2.0.0a44"
+__version__ = "2.0.0a45"
 
 if __name__ == "__main__":
     print(__version__, end="")

--- a/openlane/scripts/openroad/common/resizer.tcl
+++ b/openlane/scripts/openroad/common/resizer.tcl
@@ -105,3 +105,11 @@ proc unset_dont_touch_objects {args} {
         unset_dont_touch $::env(RSZ_DONT_TOUCH_LIST)
     }
 }
+
+
+proc set_dont_use_cells {} {
+    set_dont_use $::env(PNR_EXCLUDED_CELLS)
+    if { [info exists ::env(RSZ_DONT_USE_CELLS)] } {
+        set_dont_use $::env(RSZ_DONT_USE_CELLS)
+    }
+}

--- a/openlane/scripts/openroad/repair_design.tcl
+++ b/openlane/scripts/openroad/repair_design.tcl
@@ -19,13 +19,8 @@ read_current_odb
 
 unset_propagated_clock [all_clocks]
 
-# set don't touch nets
 set_dont_touch_objects
-
-# set don't use cells
-if { [info exists ::env(RSZ_DONT_USE_CELLS)] } {
-    set_dont_use $::env(RSZ_DONT_USE_CELLS)
-}
+set_dont_use_cells
 
 # set rc values
 source $::env(SCRIPTS_DIR)/openroad/common/set_rc.tcl

--- a/openlane/scripts/openroad/rsz_timing_postcts.tcl
+++ b/openlane/scripts/openroad/rsz_timing_postcts.tcl
@@ -19,13 +19,8 @@ read_current_odb
 
 set_propagated_clock [all_clocks]
 
-# set don't touch nets
 set_dont_touch_objects
-
-# set don't use cells
-if { [info exists ::env(RSZ_DONT_USE_CELLS)] } {
-    set_dont_use $::env(RSZ_DONT_USE_CELLS)
-}
+set_dont_use_cells
 
 # set rc values
 source $::env(SCRIPTS_DIR)/openroad/common/set_rc.tcl

--- a/openlane/scripts/openroad/rsz_timing_postgrt.tcl
+++ b/openlane/scripts/openroad/rsz_timing_postgrt.tcl
@@ -19,13 +19,8 @@ read_current_odb
 
 set_propagated_clock [all_clocks]
 
-# set don't touch nets
 set_dont_touch_objects
-
-# set don't use cells
-if { [info exists ::env(RSZ_DONT_USE_CELLS)] } {
-    set_dont_use $::env(RSZ_DONT_USE_CELLS)
-}
+set_dont_use_cells
 
 # set rc values
 source $::env(SCRIPTS_DIR)/openroad/common/set_rc.tcl

--- a/openlane/steps/common_variables.py
+++ b/openlane/steps/common_variables.py
@@ -194,20 +194,20 @@ rsz_variables = dpl_variables + [
     Variable(
         "RSZ_DONT_TOUCH_RX",
         str,
-        'A single regular expression designating nets or instances as "don\'t touch" by resizer optimizations.',
+        'A single regular expression designating nets or instances as "don\'t touch" by design repairs or resizer optimizations.',
         default="$^",
         deprecated_names=["UNBUFFER_NETS"],
     ),
     Variable(
         "RSZ_DONT_TOUCH_LIST",
         Optional[List[str]],
-        'A list of nets and instances as "don\'t touch" by resizer optimizations.',
+        'A list of nets and instances as "don\'t touch" by design repairs or resizer optimizations.',
         default=None,
     ),
     Variable(
         "RSZ_DONT_USE_CELLS",
         Optional[List[str]],
-        "An optional list of cells to not use during resizer optimizations.",
+        "An optional list of cells to not use during design repair or resizer optimizations in addition to cells that are excluded from PNR altogether.",
         deprecated_names=["DONT_USE_CELLS"],
     ),
     Variable(

--- a/openlane/steps/openroad.py
+++ b/openlane/steps/openroad.py
@@ -157,6 +157,13 @@ class OpenROADStep(TclStep):
                 for lib in self.toolbox.get_macro_views(self.config, DesignFormat.LIB)
             ]
         )
+        env["PNR_EXCLUDED_CELLS"] = shlex.join(
+            [
+                cell.strip()
+                for cell in open(self.config["PNR_EXCLUSION_CELL_LIST"]).read().split()
+                if cell.strip() != ""
+            ]
+        )
 
         return env
 
@@ -1364,7 +1371,7 @@ class CTS(ResizerStep):
             Variable(
                 "CTS_CORNERS",
                 Optional[List[str]],
-                "A list of fully-qualifiedd IPVT corners to use during clock tree synthesis. If unspecified, the value for `STA_CORNERS` from the PDK will be used.",
+                "A list of fully-qualified IPVT corners to use during clock tree synthesis. If unspecified, the value for `STA_CORNERS` from the PDK will be used.",
             ),
         ]
     )

--- a/openlane/steps/step.py
+++ b/openlane/steps/step.py
@@ -546,6 +546,7 @@ class Step(ABC):
         log_to: Optional[Union[str, os.PathLike]] = None,
         silent: bool = False,
         report_dir: Optional[Union[str, os.PathLike]] = None,
+        env: Optional[Dict[str, Any]] = None,
         **kwargs,
     ) -> Dict[str, Any]:
         """
@@ -585,9 +586,21 @@ class Step(ABC):
             kwargs["stdout"] = subprocess.PIPE
         if "stderr" not in kwargs:
             kwargs["stderr"] = subprocess.STDOUT
+
+        if env_dict := env:
+            for key, value in env_dict.items():
+                if not (
+                    isinstance(value, str)
+                    or isinstance(value, bytes)
+                    or isinstance(value, os.PathLike)
+                ):
+                    raise StepException(
+                        f"Environment variable for key '{key}' is of invalid type {type(value)}: {value}"
+                    )
         process = subprocess.Popen(
             cmd_str,
             encoding="utf8",
+            env=env,
             **kwargs,
         )
         lines = ""


### PR DESCRIPTION
* Made Magic DRC report parser more robust, handling multiple rules, etc
* Updated documentation for various related variables
* Fixed bug causing PNR-excluded cells being used during resizer-based OpenROAD steps

---
Resolves #106 