### PR TITLE
Add public CLI parse helper

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,11 @@
+# 2.0.0-a48
+
+* Created `openlane.flows.cloup_flow_opts`, which assigns a number of `cloup`
+  commandline options to an external function for convenience.
+* Moved handling of `last_run` inside `Flow.start`
+* Moved handling of volare, setting log level and threadpool count to `cloup_flow_opts`
+
+
 # 2.0.0-a47
 
 * Update Magic, Netgen, and Yosys

--- a/openlane/__main__.py
+++ b/openlane/__main__.py
@@ -22,11 +22,10 @@ from textwrap import dedent
 from functools import partial
 from typing import Tuple, Type, Optional, List, Union
 
-from click import Parameter, pass_context
+from click import Parameter, pass_context, command
 from cloup import (
     option,
     option_group,
-    command,
     HelpFormatter,
     HelpTheme,
     Style,

--- a/openlane/__main__.py
+++ b/openlane/__main__.py
@@ -202,8 +202,13 @@ def run_smoke_test(
             subprocess.check_call(["chmod", "-R", "777", final_path])
 
         pdk_root = ctx.params.get("pdk_root")
-        if pdk_root is not None:
+        if ctx.obj["use_volare"]:
+            import volare
+
+            pdk_root = volare.get_volare_home(ctx.params.get("pdk_root"))
             common.mkdirp(pdk_root)
+            volare.enable(pdk_root, "sky130", common.get_opdks_rev())
+
         config_file = os.path.join(final_path, "config.json")
 
         # 3. Run

--- a/openlane/__main__.py
+++ b/openlane/__main__.py
@@ -22,11 +22,10 @@ from textwrap import dedent
 from functools import partial
 from typing import Tuple, Type, Optional, List, Union
 
-from click import Parameter
+from click import Parameter, pass_context
 from cloup import (
     option,
     option_group,
-    pass_context,
     command,
     HelpFormatter,
     HelpTheme,

--- a/openlane/__main__.py
+++ b/openlane/__main__.py
@@ -22,10 +22,11 @@ from textwrap import dedent
 from functools import partial
 from typing import Tuple, Type, Optional, List, Union
 
-from click import Parameter, pass_context, command
+from click import Parameter, pass_context
 from cloup import (
     option,
     option_group,
+    command,
     HelpFormatter,
     HelpTheme,
     Style,
@@ -337,7 +338,7 @@ formatter_settings = HelpFormatter.settings(
 )
 @cloup_flow_opts()
 @pass_context
-def cli(ctx: Context, **kwargs):
+def cli(ctx: Context, /, **kwargs):
     args = kwargs["config_files"]
     run_kwargs = kwargs.copy()
 

--- a/openlane/__main__.py
+++ b/openlane/__main__.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 import os
 import sys
-import glob
 import shutil
 import marshal
 import tempfile
@@ -21,23 +20,23 @@ import traceback
 import subprocess
 from textwrap import dedent
 from functools import partial
-from concurrent.futures import ThreadPoolExecutor
 from typing import Tuple, Type, Optional, List, Union
 
-import click
+from click import Parameter
 from cloup import (
     option,
     option_group,
+    pass_context,
     command,
     HelpFormatter,
     HelpTheme,
     Style,
+    Context,
 )
 from cloup.constraints import (
     If,
     IsSet,
     accept_none,
-    require_one,
     mutually_exclusive,
 )
 
@@ -45,8 +44,6 @@ from cloup.constraints import (
 from .__version__ import __version__
 from .state import State
 from .logging import (
-    LogLevelsDict,
-    set_log_level,
     err,
     warn,
     info,
@@ -55,43 +52,28 @@ from . import common
 from .container import run_in_container
 from .plugins import discovered_plugins
 from .config import Config, InvalidConfig
-from .flows import Flow, SequentialFlow, FlowException, FlowError
+from .flows import Flow, SequentialFlow, FlowException, FlowError, cloup_flow_opts
 
 
 def run(
-    ctx: click.Context,
+    ctx: Context,
     flow_name: Optional[str],
-    use_volare: bool,
     pdk_root: Optional[str],
     pdk: str,
     scl: Optional[str],
     config_files: List[str],
-    run_tag: Optional[str],
+    tag: Optional[str],
     last_run: bool,
     frm: Optional[str],
     to: Optional[str],
-    only: Optional[str],
     skip: Tuple[str, ...],
-    initial_state_json: Optional[str],
+    with_initial_state: Optional[State],
     config_override_strings: List[str],
 ) -> int:
-
-    if only is not None:
-        frm = to = only
-
-    if use_volare:
-        import volare
-
-        pdk_root = volare.get_volare_home(pdk_root)
-
-        volare.enable(pdk_root, pdk[:-1], common.get_opdks_rev())
 
     config_file = config_files[0]
 
     # Enforce Mutual Exclusion
-    if run_tag is not None and last_run:
-        err("--run-tag and --last-run are mutually exclusive.")
-        return -1
 
     flow_description: Union[str, List[str]] = flow_name or "Classic"
 
@@ -136,34 +118,14 @@ def run(
         info("OpenLane will now quit.")
         return 1
 
-    initial_state: Optional[State] = None
-    if initial_state_json is not None:
-        initial_state = State.loads(open(initial_state_json).read())
-
-    if last_run:
-        runs = glob.glob(os.path.join(flow.design_dir, "runs", "*"))
-
-        latest_time: float = 0
-        latest_run: Optional[str] = None
-        for run in runs:
-            time = os.path.getmtime(run)
-            if time > latest_time:
-                latest_time = time
-                latest_run = run
-
-        if latest_run is None:
-            err("--last-run specified, but no runs found.")
-            return 1
-
-        run_tag = os.path.basename(latest_run)
-
     try:
         flow.start(
-            tag=run_tag,
+            tag=tag,
+            last_run=last_run,
             frm=frm,
             to=to,
-            skip=list(skip),
-            with_initial_state=initial_state,
+            skip=skip,
+            with_initial_state=with_initial_state,
         )
     except FlowException as e:
         err(f"The flow has encountered an unexpected error: {e}")
@@ -179,7 +141,7 @@ def run(
     return 0
 
 
-def print_version(ctx: click.Context, param: click.Parameter, value: bool):
+def print_version(ctx: Context, param: Parameter, value: bool):
     if not value:
         return
 
@@ -207,8 +169,8 @@ def print_version(ctx: click.Context, param: click.Parameter, value: bool):
 
 
 def print_bare_version(
-    ctx: click.Context,
-    param: click.Parameter,
+    ctx: Context,
+    param: Parameter,
     value: bool,
 ):
     if not value:
@@ -218,8 +180,8 @@ def print_bare_version(
 
 
 def run_smoke_test(
-    ctx: click.Context,
-    param: click.Parameter,
+    ctx: Context,
+    param: Parameter,
     value: bool,
 ):
     if not value:
@@ -241,27 +203,24 @@ def run_smoke_test(
             subprocess.check_call(["chmod", "-R", "777", final_path])
 
         pdk_root = ctx.params.get("pdk_root")
+        if pdk_root is not None:
+            common.mkdirp(pdk_root)
         config_file = os.path.join(final_path, "config.json")
-        use_volare = True
-        if use_volare_opt := ctx.params.get("use_volare"):
-            use_volare = use_volare_opt
 
         # 3. Run
         status = run(
             ctx,
             flow_name=None,
-            use_volare=use_volare,
             pdk_root=pdk_root,
             pdk="sky130A",
             scl=None,
             config_files=[config_file],
-            run_tag=None,
+            tag=None,
             last_run=False,
             frm=None,
             to=None,
-            only=None,
             skip=(),
-            initial_state_json=None,
+            with_initial_state=None,
             config_override_strings=[],
         )
         if status == 0:
@@ -281,8 +240,8 @@ def run_smoke_test(
 
 
 def cli_in_container(
-    ctx: click.Context,
-    param: click.Parameter,
+    ctx: Context,
+    param: Parameter,
     value: bool,
 ):
     if not value:
@@ -317,18 +276,7 @@ def cli_in_container(
         ctx.exit(status)
 
 
-def set_log_level_cb(
-    ctx: click.Context,
-    param: click.Parameter,
-    value: bool,
-):
-    try:
-        set_log_level(value)
-    except ValueError:
-        err(f"Invalid logging level: {value}.")
-        click.echo(ctx.get_help())
-        ctx.exit(-1)
-
+o = partial(option, show_default=True)
 
 formatter_settings = HelpFormatter.settings(
     theme=HelpTheme(
@@ -338,17 +286,6 @@ formatter_settings = HelpFormatter.settings(
         col1=Style(fg="bright_yellow"),
     )
 )
-
-
-def set_worker_count_cb(
-    ctx: click.Context,
-    param: click.Parameter,
-    value: int,
-):
-    common.set_tpe(ThreadPoolExecutor(max_workers=value))
-
-
-o = partial(option, show_default=True)
 
 
 @command(
@@ -377,41 +314,6 @@ o = partial(option, show_default=True)
     constraint=If(~IsSet("dockerized"), accept_none),
 )
 @option_group(
-    "PDK options",
-    o(
-        "--volare-pdk/--manual-pdk",
-        "use_volare",
-        is_eager=True,
-        default=True,
-        help="Automatically use Volare for PDK version installation and enablement. Set --manual if you want to use a custom PDK version.",
-    ),
-    o(
-        "--pdk-root",
-        type=click.Path(
-            exists=True,
-            file_okay=False,
-            dir_okay=True,
-        ),
-        is_eager=True,
-        default=os.environ.pop("PDK_ROOT", None),
-        help="Override volare PDK root folder. Required if Volare is not installed.",
-    ),
-    o(
-        "-p",
-        "--pdk",
-        type=str,
-        default=os.environ.pop("PDK", "sky130A"),
-        help="The process design kit to use.",
-    ),
-    o(
-        "-s",
-        "--scl",
-        type=str,
-        default=os.environ.pop("STD_CELL_LIBRARY", None),
-        help="The standard cell library to use. If None, the PDK's default standard cell library is used.",
-    ),
-)
-@option_group(
     "Subcommands",
     o(
         "--version",
@@ -435,120 +337,9 @@ o = partial(option, show_default=True)
     ),
     constraint=mutually_exclusive,
 )
-@option_group(
-    "Run options",
-    o(
-        "-f",
-        "--flow",
-        "flow_name",
-        type=click.Choice(Flow.factory.list(), case_sensitive=False),
-        default=None,
-        help="The built-in OpenLane flow to use for this run",
-    ),
-    o(
-        "-i",
-        "--with-initial-state",
-        "initial_state_json",
-        type=click.Path(
-            exists=True,
-            file_okay=True,
-            dir_okay=False,
-        ),
-        default=None,
-        help="Use this JSON file as an initial state. If this is not specified, the latest `state_out.json` of the run directory will be used if available.",
-    ),
-    o(
-        "-c",
-        "--override-config",
-        "config_override_strings",
-        type=str,
-        multiple=True,
-        help="For this run only- override a configuration variable with a certain value. In the format KEY=VALUE. Can be specified multiple times. Values must be valid JSON values.",
-    ),
-)
-@option_group(
-    "Run options - tag",
-    o(
-        "--run-tag",
-        default=None,
-        type=str,
-        help="An optional name to use for this particular run of an OpenLane-based flow.",
-    ),
-    o(
-        "--last-run",
-        is_flag=True,
-        default=False,
-        help="Use the last run as the run tag.",
-    ),
-    constraint=mutually_exclusive,
-)
-@option_group(
-    "Run options - sequential flow control",
-    o(
-        "-F",
-        "--from",
-        "frm",
-        type=str,
-        default=None,
-        help="Start from a step with this id. Supported by sequential flows.",
-    ),
-    o(
-        "-T",
-        "--to",
-        type=str,
-        default=None,
-        help="Stop at a step with this id. Supported by sequential flows.",
-    ),
-    o(
-        "--only",
-        type=str,
-        default=None,
-        help="Shorthand to set both --from and --to to the same value.",
-    ),
-    o(
-        "-S",
-        "--skip",
-        type=str,
-        multiple=True,
-        help="Skip these steps. Supported by sequential flows.",
-    ),
-    constraint=If(IsSet("only"), require_one),
-)
-@o(
-    "--log-level",
-    type=str,
-    default="VERBOSE",
-    help=dedent(
-        """
-        A logging level. Set to INFO or higher to silence subprocess logs.
-
-        You can provide either a number or a string out of the following (higher is more silent):
-        """
-    )
-    + ",".join([f"{name}={value}" for name, value in LogLevelsDict.items()]),
-    callback=set_log_level_cb,
-    expose_value=False,
-)
-@o(
-    "-j",
-    "--jobs",
-    type=int,
-    default=os.cpu_count(),
-    help="The maximum number of threads or processes that can be used by OpenLane.",
-    callback=set_worker_count_cb,
-    expose_value=False,
-)
-@click.argument(
-    "config_files",
-    nargs=-1,
-    type=click.Path(
-        exists=True,
-        file_okay=True,
-        dir_okay=True,
-    ),
-)
-@click.pass_context
-def cli(ctx: click.Context, **kwargs):
+@cloup_flow_opts()
+@pass_context
+def cli(ctx: Context, **kwargs):
     args = kwargs["config_files"]
     run_kwargs = kwargs.copy()
 

--- a/openlane/__main__.py
+++ b/openlane/__main__.py
@@ -338,7 +338,7 @@ formatter_settings = HelpFormatter.settings(
 )
 @cloup_flow_opts()
 @pass_context
-def cli(ctx: Context, /, **kwargs):
+def cli(ctx, /, **kwargs):
     args = kwargs["config_files"]
     run_kwargs = kwargs.copy()
 

--- a/openlane/__version__.py
+++ b/openlane/__version__.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-__version__ = "2.0.0a47"
+__version__ = "2.0.0a48"
 
 if __name__ == "__main__":
     print(__version__, end="")

--- a/openlane/flows/__init__.py
+++ b/openlane/flows/__init__.py
@@ -21,3 +21,4 @@ as a number of built-in flows.
 from .flow import FlowError, FlowException, FlowProgressBar, Flow
 from .sequential import SequentialFlow
 from . import builtins
+from .cli import cloup_flow_opts

--- a/openlane/flows/cli.py
+++ b/openlane/flows/cli.py
@@ -1,0 +1,359 @@
+# Copyright 2023 Efabless Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+from textwrap import dedent
+from functools import partial
+from concurrent.futures import ThreadPoolExecutor
+from typing import Optional
+
+
+from click import Parameter, echo
+from cloup import (
+    option,
+    argument,
+    option_group,
+    Context,
+    Choice,
+    Path,
+)
+from cloup.constraints import (
+    mutually_exclusive,
+)
+from cloup.typing import Decorator
+
+from openlane.state.state import InvalidState
+
+
+from .flow import Flow
+from ..common import set_tpe, get_opdks_rev
+from ..logging import set_log_level, err, LogLevelsDict
+from ..state import State
+
+
+def set_log_level_cb(
+    ctx: Context,
+    param: Parameter,
+    value: bool,
+):
+    try:
+        set_log_level(value)
+    except ValueError:
+        err(f"Invalid logging level: {value}.")
+        echo(ctx.get_help())
+        ctx.exit(-1)
+
+
+def set_worker_count_cb(
+    ctx: Context,
+    param: Parameter,
+    value: Optional[int],
+):
+    if value is None:
+        return None
+
+    set_tpe(ThreadPoolExecutor(max_workers=value))
+
+
+def initial_state_cb(
+    ctx: Context,
+    param: Parameter,
+    value: Optional[str],
+):
+    if value is None:
+        return None
+
+    try:
+        initial_state_str = open(value, encoding="utf8").read()
+    except Exception as e:
+        err(f"Failed to read initial state: {e}")
+        ctx.exit(-1)
+    try:
+        initial_state = State.loads(initial_state_str, validate_path=True)
+    except InvalidState as e:
+        err(e)
+        ctx.exit(-1)
+
+    return initial_state
+
+
+def only_cb(
+    ctx: Context,
+    param: Parameter,
+    value: Optional[str],
+):
+    if value is not None:
+        ctx.obj = ctx.obj or {}
+        ctx.obj["only"] = value
+    return value
+
+
+def from_to_cb(
+    ctx: Context,
+    param: Parameter,
+    value: Optional[str],
+):
+    if isinstance(ctx.obj, dict) and ctx.obj.get("only"):
+        return ctx.obj.get("only")
+    return value
+
+
+def use_volare_cb(
+    ctx: Context,
+    param: Parameter,
+    value: bool,
+):
+    ctx.obj = ctx.obj or {}
+    ctx.obj["use_volare"] = value
+
+
+def pdk_scl_cb(
+    ctx: Context,
+    param: Parameter,
+    value: Optional[str],
+):
+    if param.name is None:
+        return
+
+    values = ctx.params.copy()
+    values[param.name] = value
+    if "pdk" in values and "scl" in values:
+        pdk = values["pdk"]
+        pdk_family = pdk[:-1]
+        if ctx.obj and ctx.obj.get("use_volare"):
+            import volare
+
+            pdk_root = volare.get_volare_home(values["pdk_root"])
+
+            volare.enable(pdk_root, pdk_family, get_opdks_rev())
+    return value
+
+
+def cloup_flow_opts(
+    config_options: bool = True,
+    run_options: bool = True,
+    sequential_flow_controls: bool = True,
+    pdk_options: bool = True,
+    log_level: bool = True,
+    jobs: bool = True,
+    accept_config_files: bool = True,
+    volare_by_default: bool = True,
+) -> Decorator:
+    """
+    Returns a wrapper that appends a number of OpenLane flow-related flags to a
+    function decorated with `@cloup.command https://cloup.readthedocs.io/en/stable/autoapi/cloup/index.html#cloup.command`_.
+
+    The following keyword arguments will be passed to the decorated function.
+    * Those postfixed ‡ are compatible with the constructor for :class:`Flow`.
+    * Those postfixed § are compatible with the :meth:`Flow.start`.
+
+    * Flow configuration options (if parameter ``config_options`` is ``True``):
+        * ``flow_name``: ``Optional[str]``: A valid flow ID to be used with :meth:`Flow.factory.get`
+        * ``config_override_strings``‡: ``Optional[Iterable[str]]``
+    * Sequential flow controls (if parameter ``sequential_flow_controls`` is ``True``)
+        * ``frm``§: ``str``: Start from a step with this ID. Supported by sequential flows.
+        * ``to``§: ``str``: Stop at a step with this id. Supported by sequential flows.
+        * ``skip``§: ``Iterable[str]``: Skip these steps. Supported by sequential flows.
+    * Flow run options (if parameter ``run_options`` is ``True``):
+        * ``tag``§: ``Optional[str]``
+        * ``last_run``§: ``bool``: If ``True``, ``tag`` is guaranteed to be None.
+        * ``with_initial_state``§: ``Optional[State]``
+    * PDK options
+        * ``use_volare``: ``bool``
+        * ``pdk_root``‡: ``Optional[str]``
+        * ``pdk``‡: ``str``
+        * ``scl``‡: ``Optional[str]``
+    * ``config_files``: ``Iterable[str]``: Paths to configuration files (if
+      parameter  ``accept_config_files`` is ``True``)
+
+    :param config_options: Enables flow configuration and starting CLI flags
+    :param sequential_flow_controls: Enables flow control CLI flags
+    :param flow_run_options: Enables tag CLI flags
+    :param pdk_options: Enables PDK CLI flags
+    :param log_level: Enables ``--log-level`` CLI flag
+    :param jobs: Enables ``-j/--jobs`` CLI flag
+    :param accept_config_files: Accepts configuration file paths as CLI arguments
+    :param volare_by_default: If ``pdk_options`` is ``True``, this changes whether
+        Volare is used by default for this CLI or not.
+    """
+    o = partial(option, show_default=True)
+
+    def decorator(f):
+        if config_options:
+            f = option_group(
+                "Flow configuration options",
+                o(
+                    "-f",
+                    "--flow",
+                    "flow_name",
+                    type=Choice(Flow.factory.list(), case_sensitive=False),
+                    default=None,
+                    help="The built-in OpenLane flow to use for this run",
+                ),
+                o(
+                    "-c",
+                    "--override-config",
+                    "config_override_strings",
+                    type=str,
+                    multiple=True,
+                    help="For this run only- override a configuration variable with a certain value. In the format KEY=VALUE. Can be specified multiple times. Values must be valid JSON values.",
+                ),
+            )(f)
+        if run_options:
+            f = option_group(
+                "Run options",
+                o(
+                    "--run-tag",
+                    "tag",
+                    default=None,
+                    type=str,
+                    help="An optional name to use for this particular run of an OpenLane-based flow. Used to create the run directory.",
+                ),
+                o(
+                    "-i",
+                    "--with-initial-state",
+                    type=Path(
+                        exists=True,
+                        file_okay=True,
+                        dir_okay=False,
+                    ),
+                    default=None,
+                    callback=initial_state_cb,
+                    help="Use this JSON file as an initial state. If this is not specified, the latest `state_out.json` of the run directory will be used if available.",
+                ),
+                o(
+                    "--last-run",
+                    is_flag=True,
+                    default=False,
+                    help="Use the last run as the run tag.",
+                ),
+                constraint=mutually_exclusive,
+            )(f)
+        if sequential_flow_controls:
+            f = option_group(
+                "Sequential flow controls",
+                o(
+                    "-F",
+                    "--from",
+                    "frm",
+                    type=str,
+                    default=None,
+                    callback=from_to_cb,
+                    help="Start from a step with this id. Supported by sequential flows.",
+                ),
+                o(
+                    "-T",
+                    "--to",
+                    type=str,
+                    default=None,
+                    callback=from_to_cb,
+                    help="Stop at a step with this id. Supported by sequential flows.",
+                ),
+                o(
+                    "--only",
+                    type=str,
+                    default=None,
+                    expose_value=False,
+                    is_eager=True,
+                    callback=only_cb,
+                    help="Shorthand to set both --from and --to to the same value. Overrides the values from both.",
+                ),
+                o(
+                    "-S",
+                    "--skip",
+                    type=str,
+                    multiple=True,
+                    help="Skip these steps. Supported by sequential flows.",
+                ),
+            )(f)
+        if log_level:
+            f = o(
+                "--log-level",
+                type=str,
+                default="VERBOSE",
+                help=dedent(
+                    """
+                    A logging level. Set to INFO or higher to silence subprocess logs.
+
+                    You can provide either a number or a string out of the following (higher is more silent):
+                    """
+                )
+                + ",".join(
+                    [f"{name}={value}" for name, value in LogLevelsDict.items()]
+                ),
+                callback=set_log_level_cb,
+                expose_value=False,
+            )(f)
+        if pdk_options:
+            f = option_group(
+                "PDK options",
+                o(
+                    "--volare-pdk/--manual-pdk",
+                    "use_volare",
+                    is_eager=True,
+                    default=volare_by_default,
+                    help="Automatically use Volare for PDK version installation and enablement. Set --manual if you want to use a custom PDK version.",
+                    expose_value=False,
+                    callback=use_volare_cb,
+                ),
+                o(
+                    "--pdk-root",
+                    type=Path(
+                        exists=True,
+                        file_okay=False,
+                        dir_okay=True,
+                    ),
+                    is_eager=True,
+                    default=os.environ.pop("PDK_ROOT", None),
+                    help="Override volare PDK root folder. Required if Volare is not installed.",
+                ),
+                o(
+                    "-p",
+                    "--pdk",
+                    type=str,
+                    default=os.environ.pop("PDK", "sky130A"),
+                    help="The process design kit to use.",
+                    callback=pdk_scl_cb,
+                ),
+                o(
+                    "-s",
+                    "--scl",
+                    type=str,
+                    default=os.environ.pop("STD_CELL_LIBRARY", None),
+                    help="The standard cell library to use. If None, the PDK's default standard cell library is used.",
+                    callback=pdk_scl_cb,
+                ),
+            )(f)
+        if jobs:
+            f = o(
+                "-j",
+                "--jobs",
+                type=int,
+                default=os.cpu_count(),
+                help="The maximum number of threads or processes that can be used by OpenLane.",
+                callback=set_worker_count_cb,
+                expose_value=False,
+            )(f)
+        if accept_config_files:
+            f = argument(
+                "config_files",
+                nargs=-1,
+                type=Path(
+                    exists=True,
+                    file_okay=True,
+                    dir_okay=True,
+                ),
+            )(f)
+        return f
+
+    return decorator

--- a/openlane/flows/sequential.py
+++ b/openlane/flows/sequential.py
@@ -14,7 +14,7 @@
 from __future__ import annotations
 
 import os
-from typing import List, Tuple, Optional, Type, Dict, Union
+from typing import Iterable, List, Tuple, Optional, Type, Dict, Union
 
 from .flow import Flow, FlowException, FlowError
 from ..state import State
@@ -113,7 +113,7 @@ class SequentialFlow(Flow):
         initial_state: State,
         frm: Optional[str] = None,
         to: Optional[str] = None,
-        skip: Optional[List[str]] = None,
+        skip: Optional[Iterable[str]] = None,
         **kwargs,
     ) -> Tuple[State, List[Step]]:
         step_ids = {cls.id.lower(): cls.id for cls in reversed(self.Steps)}

--- a/openlane/logging/__init__.py
+++ b/openlane/logging/__init__.py
@@ -149,8 +149,8 @@ def warn(printable, *args, **kwargs):
 
 def err(printable, *args, **kwargs):
     """
-    Logs an item to the terminal with a warning unicode character and
-    gold/bold formatting.
+    Logs an item to the terminal with an error unicode character and
+    red/bold formatting.
     """
     if get_log_level() > LogLevels.ERROR:
         return

--- a/openlane/state/state.py
+++ b/openlane/state/state.py
@@ -245,7 +245,11 @@ class State(GenericImmutableDict[str, StateElement]):
 
     @classmethod
     def loads(Self, json_in: str, validate_path: bool = True) -> "State":
-        raw = json.loads(json_in, parse_float=Decimal)
+        try:
+            raw = json.loads(json_in, parse_float=Decimal)
+        except json.JSONDecodeError as e:
+            raise InvalidState(f"Invalid JSON string provided for state: {e}")
+
         if not isinstance(raw, dict):
             raise InvalidState("Failed to load state: JSON result is a dictionary")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 click>=8,<9
-cloup>=1,<2
+cloup>=1.0.1,<2
 pyyaml>=5,<7
 rich>=12,<13
 requests>=2.27,<3


### PR DESCRIPTION
* Created `openlane.flows.cloup_flow_opts`, which assigns a number of `cloup`
  commandline options to an external function for convenience.
* Moved handling of `last_run` inside `Flow.start`
* Moved handling of volare, setting log level and threadpool count to `cloup_flow_opts`