### PR TITLE
Extract shorts as resistors (during magic SPICE extraction)

### DIFF
--- a/openlane/scripts/magic/extract_spice.tcl
+++ b/openlane/scripts/magic/extract_spice.tcl
@@ -38,6 +38,7 @@ if { ! $::env(MAGIC_NO_EXT_UNIQUE) } {
 extract
 
 ext2spice lvs
+ext2spice short resistor
 ext2spice -o $netlist $::env(DESIGN_NAME).ext
 feedback save $feedback_file
 # exec cp $::env(DESIGN_NAME).spice $::env(signoff_results)/$::env(DESIGN_NAME).spice

--- a/openlane/scripts/magic/extract_spice.tcl
+++ b/openlane/scripts/magic/extract_spice.tcl
@@ -38,7 +38,10 @@ if { ! $::env(MAGIC_NO_EXT_UNIQUE) } {
 extract
 
 ext2spice lvs
+
+# For designs where more than one top-level pin is connected to the same net
 ext2spice short resistor
+
 ext2spice -o $netlist $::env(DESIGN_NAME).ext
 feedback save $feedback_file
 # exec cp $::env(DESIGN_NAME).spice $::env(signoff_results)/$::env(DESIGN_NAME).spice


### PR DESCRIPTION
This fixes LVS failures when more than two pins are connected to the same net. See #111 for details.