### PR TITLE
Fix Tcl String Escaping

### DIFF
--- a/.github/test_sets/test_sets.yml
+++ b/.github/test_sets/test_sets.yml
@@ -15,6 +15,7 @@
     - gcd
     - caravel_upw
     - io_placer
+    - test_sram_macro
 - scl: sky130A/sky130_fd_sc_hd
   name: extended_test_set
   designs:

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+# 2.0.0-a53
+* Reworked Tcl unsafe string escaping to use home-cooked functions instead of
+  "shlex"
+
 # 2.0.0-a52
 
 * Added three designs to the gf180mcu test set

--- a/designs/test_sram_macro/config.json
+++ b/designs/test_sram_macro/config.json
@@ -4,22 +4,16 @@
     "CLOCK_PORT": "clk",
     "CLOCK_PERIOD": 25.0,
     "DESIGN_IS_CORE": true,
-
     "FP_SIZING": "absolute",
     "DIE_AREA": "0 0 750 1250",
     "PL_TARGET_DENSITY": 0.5,
-
     "VDD_NETS": "vccd1",
     "GND_NETS": "vssd1",
-
     "FP_PDN_MACRO_HOOKS": "submodule.sram0 vccd1 vssd1 vccd1 vssd1, submodule.sram1 vccd1 vssd1 vccd1 vssd1",
-    
     "MACRO_PLACEMENT_CFG": "dir::macro_placement.cfg",
-
-    "EXTRA_LEFS":      "/openlane/pdks/sky130B/libs.ref/sky130_sram_macros/lef/sky130_sram_1kbyte_1rw1r_32x256_8.lef",
-    "EXTRA_GDS_FILES": "/openlane/pdks/sky130B/libs.ref/sky130_sram_macros/gds/sky130_sram_1kbyte_1rw1r_32x256_8.gds",
-    "EXTRA_LIBS":      "/openlane/pdks/sky130B/libs.ref/sky130_sram_macros/lib/sky130_sram_1kbyte_1rw1r_32x256_8_TT_1p8V_25C.lib",
-
+    "EXTRA_LEFS": "pdk_dir::libs.ref/sky130_sram_macros/lef/sky130_sram_1kbyte_1rw1r_32x256_8.lef",
+    "EXTRA_GDS_FILES": "pdk_dir::libs.ref/sky130_sram_macros/gds/sky130_sram_1kbyte_1rw1r_32x256_8.gds",
+    "EXTRA_LIBS": "pdk_dir::libs.ref/sky130_sram_macros/lib/sky130_sram_1kbyte_1rw1r_32x256_8_TT_1p8V_25C.lib",
     "RUN_KLAYOUT_XOR": false,
     "MAGIC_DRC_USE_GDS": false,
     "QUIT_ON_MAGIC_DRC": false

--- a/openlane/__version__.py
+++ b/openlane/__version__.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-__version__ = "2.0.0a52"
+__version__ = "2.0.0a53"
 
 if __name__ == "__main__":
     print(__version__, end="")

--- a/openlane/scripts/openroad/common/set_global_connections.tcl
+++ b/openlane/scripts/openroad/common/set_global_connections.tcl
@@ -35,15 +35,7 @@ proc set_global_connections {} {
     }
     if { $::env(PDN_CONNECT_MACROS_TO_GRID) == 1 &&
         [info exists ::env(PDN_MACRO_CONNECTIONS)]} {
-        set pdn_hooks \
-            [lmap \
-                {a b c d e} \
-                $::env(PDN_MACRO_CONNECTIONS) \
-                {list $a $b $c $d $e} \
-            ]
-        puts "$pdn_hooks"
-
-        foreach pdn_hook $pdn_hooks {
+        foreach pdn_hook $::env(PDN_MACRO_CONNECTIONS) {
             set instance_name [lindex $pdn_hook 0]
             set power_net [lindex $pdn_hook 1]
             set ground_net [lindex $pdn_hook 2]

--- a/openlane/steps/openroad.py
+++ b/openlane/steps/openroad.py
@@ -157,7 +157,7 @@ class OpenROADStep(TclStep):
                 for lib in self.toolbox.get_macro_views(self.config, DesignFormat.LIB)
             ]
         )
-        env["PNR_EXCLUDED_CELLS"] = shlex.join(
+        env["PNR_EXCLUDED_CELLS"] = self.join(
             [
                 cell.strip()
                 for cell in open(self.config["PNR_EXCLUSION_CELL_LIST"]).read().split()

--- a/openlane/steps/tclstep.py
+++ b/openlane/steps/tclstep.py
@@ -27,7 +27,7 @@ from decimal import Decimal
 from collections import deque
 from dataclasses import is_dataclass, asdict
 from os.path import join, dirname, isdir, relpath
-from typing import Any, ClassVar, List, Dict, Sequence, Union, Tuple
+from typing import Any, ClassVar, Iterable, List, Dict, Sequence, Union, Tuple
 
 from .step import ViewsUpdate, MetricsUpdate, Step, StepException
 
@@ -321,6 +321,10 @@ def create_reproducible(
     return destination_folder
 
 
+_find_unsafe = re.compile(r"[^\w@%+=:,./-]", re.ASCII).search
+_escapes_in_quotes = re.compile(r"([\\\$\"\[])")
+
+
 class TclStep(Step):
     """
     A subclass of :class:`Step` that primarily deals with running Tcl-based utilities,
@@ -333,6 +337,22 @@ class TclStep(Step):
     """
 
     reproducibles_allowed: ClassVar[bool] = True
+
+    @staticmethod
+    def escape(s: str) -> str:
+        """
+        :returns: If the string can be parsed by Tcl as a single token, the string
+            is returned verbatim.
+
+            Otherwise
+        """
+        if not _find_unsafe(s):
+            return s
+        return '"' + _escapes_in_quotes.sub(r"\\\1", s) + '"'
+
+    @staticmethod
+    def join(ss: Iterable[str]) -> str:
+        return " ".join(TclStep.escape(arg) for arg in ss)
 
     @staticmethod
     def value_to_tcl(value: Any) -> str:
@@ -353,13 +373,13 @@ class TclStep(Step):
             result = []
             for item in value:
                 result.append(TclStep.value_to_tcl(item))
-            return shlex.join(result)
+            return TclStep.join(result)
         elif isinstance(value, dict):
             result = []
             for v_key, v_value in value.items():
                 result.append(TclStep.value_to_tcl(v_key))
                 result.append(TclStep.value_to_tcl(v_value))
-            return shlex.join(result)
+            return TclStep.join(result)
         elif isinstance(value, Enum):
             return value.name
         elif isinstance(value, bool):


### PR DESCRIPTION
* Reworked Tcl unsafe string escaping to use home-cooked functions instead of
  "shlex"

---
Resolves #90 