### PR TITLE
Short Resistors in Magic Spice Extraction

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,9 @@
+# 2.0.0-b2
+
+* Updated Magic to `952b20d`
+* Added new variable, `MAGIC_EXT_SHORT_RESISTOR` to `Magic.SpiceExtraction`,
+  disabled by default
+
 # 2.0.0-b1
 
 * Added unit testing and coverage reporting for core infrastructure features (80%+)
@@ -5,7 +11,8 @@
 * Moved CI designs out-of-tree
 * Various documentation improvements
 * Common Module
-  * Created new TclUtils to handle common Tcl interactions, i.e., evaluating the environment and testing
+  * Created new TclUtils to handle common Tcl interactions, i.e., evaluating the
+    environment and testing
   * Made Tcl environment evaluation no longer rely on the filesystem
   * Made Tcl environment evaluation restore the environment after the fact
   * Moved `Path` from State module to common
@@ -17,7 +24,8 @@
 * Flow Module
   * Sequential flows now handle duplicate Step IDs by adding a suffix
 * Logging Module
-  * Logging rewritten to use Python logger with rich handler, the latter of which suppressed during unit testing
+  * Logging rewritten to use Python logger with rich handler, the latter of
+  which suppressed during unit testing
  * State Module
   * `.save_snapshot()` now also saves a JSON representation of metrics
   * Fixed metric cloning

--- a/nix/magic.nix
+++ b/nix/magic.nix
@@ -44,7 +44,7 @@ with pkgs; clangStdenv.mkDerivation rec {
     owner = "RTimothyEdwards";
     repo = "magic";
     inherit rev;
-    sha256 = "sha256-Kz8ygEfpLexiHnETxrlLeAdwxSBMIyTSDYq2/183rYo=";
+    sha256 = "sha256-g5sFmCB1HBFsD7bViakMf58Y/bCAXw1oFy/SKuBYr8M=";
   };
 
   patches = [

--- a/nix/magic.nix
+++ b/nix/magic.nix
@@ -38,7 +38,7 @@
 
 with pkgs; clangStdenv.mkDerivation rec {
   name = "magic-vlsi";
-  rev = "0afe4d87d4aacfbbb2659129a1858a22d216a920";
+  rev = "952b20d2a2a23306b7dd2f3398dd1479ed8e24c6";
 
   src = fetchFromGitHub {
     owner = "RTimothyEdwards";

--- a/openlane/__version__.py
+++ b/openlane/__version__.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-__version__ = "2.0.0b1"
+__version__ = "2.0.0b2"
 
 if __name__ == "__main__":
     print(__version__, end="")

--- a/openlane/scripts/magic/extract_spice.tcl
+++ b/openlane/scripts/magic/extract_spice.tcl
@@ -38,6 +38,12 @@ if { ! $::env(MAGIC_NO_EXT_UNIQUE) } {
 extract
 
 ext2spice lvs
+
+# For designs where more than one top-level pin is connected to the same net
+if { $::env(MAGIC_EXT_SHORT_RESISTOR) } {
+    ext2spice short resistor
+}
+
 ext2spice -o $netlist $::env(DESIGN_NAME).ext
 feedback save $feedback_file
 # exec cp $::env(DESIGN_NAME).spice $::env(signoff_results)/$::env(DESIGN_NAME).spice

--- a/openlane/steps/magic.py
+++ b/openlane/steps/magic.py
@@ -307,6 +307,12 @@ class SpiceExtraction(MagicStep):
             default=False,
             deprecated_names=["LVS_CONNECT_BY_LABEL"],
         ),
+        Variable(
+            "MAGIC_EXT_SHORT_RESISTOR",
+            bool,
+            "Enables adding resistors to shorts- resolves LVS issues if more than one top-level pin is connected to the same net, but may increase runtime and break some designs. Proceed with caution.",
+            default=False,
+        ),
     ]
 
     def get_script_path(self):


### PR DESCRIPTION
* Updated Magic to `952b20d`
* Added new variable, `MAGIC_EXT_SHORT_RESISTOR` to `Magic.SpiceExtraction`,
  disabled by default

Originally reported by @urish, @tnt