### PR TITLE
Bump Volare to 0.11.2

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,7 +1,7 @@
 # 2.0.0-b4
 
 * Updated documentation for `run_subprocess`
-* Updated Volare to `0.11.0`
+* Updated Volare to `0.11.2`
 * Fixed a bug with `Toolbox` method memoization
 * Unknown key errors only emit a warning now if the key is used as a Variable's
   name *anywhere* linked to OpenLane. This allows using the same config file

--- a/default.nix
+++ b/default.nix
@@ -29,8 +29,8 @@
 
   yosys ? import ./nix/yosys.nix { inherit pkgs; },
   
-  volare-rev ? "0faec9ea41ff4a27551296f6017758409287fd92",
-  volare-sha256 ? "sha256-nwDfYftrox9L7ryrwv3qxmvLfSUr7XBcVQofWgmNtDU=",
+  volare-rev ? "2775640b422afa3c1c0016c4a46da5fa23026a93",
+  volare-sha256 ? "sha256-a7I4Tg6tzFGFo3u2zQIKScboOX4OFO4FdqBKbcxEEl0=",
   volare ? let src = pkgs.fetchFromGitHub {
     owner = "efabless";
     repo = "volare";

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ cloup>=1.0.1,<2
 pyyaml>=5,<7
 rich>=12,<13
 requests>=2.27,<3
-volare>=0.11.0
+volare>=0.11.2
 lxml>=4.9.0
 deprecated>=1.2.10,<2


### PR DESCRIPTION
Better diagnostics on `enable` failures - turns out the transient failures were rate-limiting