### PR TITLE
Pin Sphinx 7.1 (and other versions)

### DIFF
--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -1,8 +1,9 @@
 # docs
-furo
-docutils>=0.17
-sphinx>=4
+furo==2023.7.26 
+docutils>=0.17,<1
+sphinx==7.1.*
 sphinx-autobuild>=2021.3.14
-sphinx-autodoc-typehints
-myst-parser>=0.18.0
-docstring-parser
+sphinx-autodoc-typehints>=1.24.0
+sphinx-design>=0.5.0,<1
+myst-parser>=2.0.0,<3
+docstring-parser>=0.15,<1


### PR DESCRIPTION
Sphinx 7.2 has a number of breaking changes: https://github.com/sphinx-doc/sphinx/issues/11608

We've been running into one with furo specifically, where it thinks a `html_style` is set for some reason.