### PR TITLE
STA: rename max transition violations count metric 

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,9 @@
+# 2.0.0-b8
+
+* Rename incorrectly-named metric rename `clock__max_slew_violation__count` to
+  `design__max_slew_violation__count`
+* Fix clock skew metric aggregation by using `-inf` instead of `inf`
+
 # 2.0.0-b7
 
 * Internally reworked `Config` module

--- a/openlane/__version__.py
+++ b/openlane/__version__.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-__version__ = "2.0.0b7"
+__version__ = "2.0.0b8"
 
 if __name__ == "__main__":
     print(__version__, end="")

--- a/openlane/scripts/openroad/sta/corner.tcl
+++ b/openlane/scripts/openroad/sta/corner.tcl
@@ -100,7 +100,7 @@ report_parasitic_annotation -report_unannotated
 
 puts "\n==========================================================================="
 puts "max slew violation count [sta::max_slew_violation_count]"
-write_metric_int "clock__max_slew_violation__count__corner:[$corner name]" [sta::max_slew_violation_count]
+write_metric_int "design__max_slew_violation__count__corner:[$corner name]" [sta::max_slew_violation_count]
 puts "max fanout violation count [sta::max_fanout_violation_count]"
 write_metric_int "design__max_fanout_violation__count__corner:[$corner name]" [sta::max_fanout_violation_count]
 puts "max cap violation count [sta::max_capacitance_violation_count]"

--- a/openlane/scripts/openroad/sta/multi_corner.tcl.bk
+++ b/openlane/scripts/openroad/sta/multi_corner.tcl.bk
@@ -107,7 +107,7 @@ if { [info exists ::env(CURRENT_CORNER_NAME)] } {
     set corner_postfix "__corner:$::env(CURRENT_CORNER_NAME)"
 }
 puts "max slew violation count [sta::max_slew_violation_count]"
-write_metric_int "clock__max_slew_violation__count$corner_postfix" [sta::max_slew_violation_count]
+write_metric_int "design__max_slew_violation__count$corner_postfix" [sta::max_slew_violation_count]
 puts "max fanout violation count [sta::max_fanout_violation_count]"
 write_metric_int "design__max_fanout_violation__count$corner_postfix" [sta::max_fanout_violation_count]
 puts "max cap violation count [sta::max_capacitance_violation_count]"

--- a/openlane/steps/openroad.py
+++ b/openlane/steps/openroad.py
@@ -73,11 +73,11 @@ timing_metric_aggregation: Dict[str, Tuple[Any, Callable[[Iterable], Any]]] = {
     "timing__hold_r2r_vio__count": (0, lambda x: sum(x)),
     "timing__setup_vio__count": (0, lambda x: sum(x)),
     "timing__setup_r2r_vio__count": (0, lambda x: sum(x)),
-    "clock__max_slew_violation__count": (0, lambda x: sum(x)),
+    "design__max_slew_violation__count": (0, lambda x: sum(x)),
     "design__max_fanout_violation__count": (0, lambda x: sum(x)),
     "design__max_cap_violation__count": (0, lambda x: sum(x)),
-    "clock__skew__worst_hold": (inf, max),
-    "clock__skew__worst_setup": (inf, max),
+    "clock__skew__worst_hold": (-inf, max),
+    "clock__skew__worst_setup": (-inf, max),
     "timing__hold__ws": (inf, min),
     "timing__setup__ws": (inf, min),
     "timing__hold__wns": (inf, min),
@@ -458,7 +458,7 @@ class STAPostPNR(STAPrePNR):
                 "timing__setup_vio__count",
                 "timing__setup_r2r_vio__count",
                 "design__max_cap_violation__count",
-                "clock__max_slew_violation__count",
+                "design__max_slew_violation__count",
             ]:
                 row.append(
                     format_count(


### PR DESCRIPTION
~ rename `clock__max_slew_violation__count` to `design__max_slew_violation__count`
~ fix clk skew metric aggregation to use `-inf` instead of `inf` 