### PR TITLE
Logging Adjustments

### DIFF
--- a/openlane/logging/__init__.py
+++ b/openlane/logging/__init__.py
@@ -26,6 +26,8 @@ from .logger import (
     set_log_level,
     reset_log_level,
     get_log_level,
+    register_additional_handler,
+    deregister_additional_handler,
     verbose,
     debug,
     info,

--- a/openlane/logging/logger.py
+++ b/openlane/logging/logger.py
@@ -74,15 +74,47 @@ def __logger():
 __openlane_logger = __logger()
 
 
+def register_additional_handler(handler: logging.Handler):
+    """
+    Adds a new handler to the default OpenLane logger.
+
+    :param handler: The new handler. Must be of type ``logging.Handler``
+        or its subclasses.
+    """
+    __openlane_logger.addHandler(handler)
+
+
+def deregister_additional_handler(handler: logging.Handler):
+    """
+    Removes a registered handler from the default OpenLane logger.
+
+    :param handler: The handler. If not registered, the behavior
+        of this function is undefined.
+    """
+    __openlane_logger.removeHandler(handler)
+
+
 def set_log_level(lv: Union[str, int]):
+    """
+    Sets the log level of the default OpenLane logger.
+
+    :param lv: Either the name or number of the desired log level.
+    """
     __openlane_logger.setLevel(lv)
 
 
 def reset_log_level():
+    """
+    Sets the log level of the default OpenLane logger back to the
+    default log level.
+    """
     set_log_level("VERBOSE")
 
 
 def get_log_level() -> int:
+    """
+    Obtains the numeric log level of the OpenLane logger.
+    """
     return __openlane_logger.getEffectiveLevel()
 
 

--- a/openlane/steps/openroad.py
+++ b/openlane/steps/openroad.py
@@ -42,7 +42,7 @@ from .common_variables import (
 
 from ..config import Variable
 from ..state import State, DesignFormat
-from ..logging import debug, err, info, warn, console, verbose
+from ..logging import debug, err, info, warn, verbose
 from ..common import (
     Path,
     TclUtils,

--- a/openlane/steps/openroad.py
+++ b/openlane/steps/openroad.py
@@ -42,7 +42,7 @@ from .common_variables import (
 
 from ..config import Variable
 from ..state import State, DesignFormat
-from ..logging import debug, err, info, warn, console
+from ..logging import debug, err, info, warn, console, verbose
 from ..common import (
     Path,
     TclUtils,
@@ -467,7 +467,7 @@ class STAPostPNR(STAPrePNR):
                 )
             table.add_row(*row)
 
-        console.print(table)
+        verbose(table)
         with open(os.path.join(self.step_dir, "summary.rpt"), "w") as f:
             rich.print(table, file=f)
 


### PR DESCRIPTION
* `Flow.start()` now registers two handlers, one for errors and one for warnings, and forwards them to `step_dir/{errors,warnings}.log` respectively
* Table no longer prints if log level is higher than `VERBOSE`

---
Resolves #140 
Resolves #147