### PR TITLE
Fix Reproducible Ejection Bugs

### DIFF
--- a/openlane/common/toolbox.py
+++ b/openlane/common/toolbox.py
@@ -50,7 +50,7 @@ class Toolbox(object):
     """
 
     def __init__(self, tmp_dir: str) -> None:
-        self.tmp_dir = os.path.abspath(tmp_dir)
+        self.tmp_dir = tmp_dir
         self.remove_cells_from_lib = lru_cache(16, True)(self.remove_cells_from_lib)  # type: ignore
 
     @deprecated(

--- a/openlane/steps/odb.py
+++ b/openlane/steps/odb.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 import os
 import re
-import sys
 import json
 import shutil
 from math import inf
@@ -27,7 +26,7 @@ from .step import ViewsUpdate, MetricsUpdate, Step, StepException
 from ..logging import warn
 from ..config import Variable, Macro
 from ..state import State, DesignFormat
-from ..common import Path, get_openlane_root, get_script_dir, StringEnum
+from ..common import Path, get_script_dir, StringEnum
 
 inf_rx = re.compile(r"\b(-?)inf\b")
 
@@ -52,9 +51,6 @@ class OdbpyStep(Step):
         command += [
             str(state_in[DesignFormat.ODB]),
         ]
-
-        env["OPENLANE_ROOT"] = get_openlane_root()
-        env["ODB_PYTHONPATH"] = ":".join(sys.path)
 
         generated_metrics = self.run_subprocess(
             command,

--- a/openlane/steps/step.py
+++ b/openlane/steps/step.py
@@ -563,9 +563,6 @@ class Step(ABC):
             "step": self.__class__.id,
         }
 
-        # pdk_root = dumpable_config["PDK_ROOT"]
-        # pdk_root_resolved = os.path.join(".", "files", pdk_root[1:])
-        # dumpable_config["PDK_ROOT"] = pdk_root_resolved
         del dumpable_config["PDK_ROOT"]
 
         config_path = os.path.join(target_dir, "config.json")

--- a/openlane/steps/tclstep.py
+++ b/openlane/steps/tclstep.py
@@ -125,7 +125,7 @@ class TclStep(Step):
         """
         env = env.copy()
 
-        env["SCRIPTS_DIR"] = get_script_dir()
+        env["SCRIPTS_DIR"] = os.path.abspath(get_script_dir())
         env["STEP_DIR"] = os.path.abspath(self.step_dir)
 
         tech_lefs = self.toolbox.filter_views(self.config, self.config["TECH_LEFS"])


### PR DESCRIPTION
* Reduced reliance on absolute paths
   * Special exception carved out for `STEP_DIR`, `SCRIPTS_DIR`
* scripts directory copied in entirety into ejected reproducibles
* Removed dependency on State module from `odb` scripts
* Removed custom PYTHONPATH setting from `OdbStep` (which was mostly to mitigate problems fixed in #86)