### PR TITLE
Add Docker TTY Commandline Flag + Have CI test `--dockerized` specifically

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,13 +133,16 @@ jobs:
           IMAGE_PATH=$(nix-build --argstr name openlane --argstr tag-override tmp-amd64 docker.nix)
           echo "IMAGE_PATH=$IMAGE_PATH" >> $GITHUB_ENV
           cat $IMAGE_PATH | docker load
+      - name: Set Up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.8"
+      - name: Install Dependencies
+        run: make venv
       - name: Smoke-Test Docker Image
         run: |
-          docker run --rm\
-            -v /tmp:/tmp\
-            -e TMPDIR=/tmp\
-            openlane:tmp-amd64\
-            openlane --smoke-test
+          OPENLANE_IMAGE_OVERRIDE=openlane:tmp-amd64\
+            ./venv/bin/python3 -m openlane --docker-no-tty --dockerized --smoke-test
       - name: Upload Docker Artifact
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,7 +142,11 @@ jobs:
       - name: Smoke-Test Docker Image
         run: |
           OPENLANE_IMAGE_OVERRIDE=openlane:tmp-amd64\
-            ./venv/bin/python3 -m openlane --docker-no-tty --dockerized --smoke-test
+            ./venv/bin/python3 -m openlane\
+              --docker-mount $PWD/.volare:$HOME/.volare\
+              --docker-no-tty\
+              --dockerized\
+              --smoke-test
       - name: Upload Docker Artifact
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,9 +141,10 @@ jobs:
         run: make venv
       - name: Smoke-Test Docker Image
         run: |
+          mkdir -p $HOME/.volare
+          chmod -R 755 $HOME/.volare
           OPENLANE_IMAGE_OVERRIDE=openlane:tmp-amd64\
             ./venv/bin/python3 -m openlane\
-              --docker-mount $PWD/.volare:$HOME/.volare\
               --docker-no-tty\
               --dockerized\
               --smoke-test

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,8 @@
+# 2.0.0-b10
+
+* Add new commandline options: `--docker-tty/--docker-no-tty`, controlling the `-t` flag of Docker and compatible container engines which allocates a virtual tty
+* Convert CI to use `--dockerized` instead of a plain `docker run`
+
 # 2.0.0-b9
 
 * `Flow.start()` now registers two handlers, one for errors and one for warnings, and forwards them to `step_dir/{errors,warnings}.log` respectively

--- a/openlane/__main__.py
+++ b/openlane/__main__.py
@@ -256,7 +256,7 @@ def cli_in_container(
 
     status = 0
     docker_mounts = list(ctx.params.get("docker_mounts") or ())
-    docker_tty: bool = ctx.params.get("docker_tty")
+    docker_tty: bool = ctx.params.get("docker_tty", False)
     pdk_root = ctx.params.get("pdk_root")
     argv = sys.argv[sys.argv.index("--dockerized") + 1 :]
 
@@ -266,7 +266,9 @@ def cli_in_container(
         final_argv = ["openlane"] + argv
         interactive = False
 
-    docker_image = os.getenv("OPENLANE_IMAGE_OVERRIDE", f"ghcr.io/efabless/openlane2:{__version__}")
+    docker_image = os.getenv(
+        "OPENLANE_IMAGE_OVERRIDE", f"ghcr.io/efabless/openlane2:{__version__}"
+    )
 
     try:
         status = run_in_container(

--- a/openlane/__main__.py
+++ b/openlane/__main__.py
@@ -302,20 +302,20 @@ o = partial(option, show_default=True)
         multiple=True,
         is_eager=True,  # docker options should be processed before anything else
         default=(),
-        help="Additionally mount this directory in dockerized mode. Can be supplied multiple times to mount multiple directories. Must be passed before --dockerized, has no effect if --dockerized is not set.",
+        help="Used to mount more directories in dockerized mode. If a valid directory is specified, it will be mounted in the same path in the container. Otherwise, the value of the option will be passed to the Docker-compatible container engine verbatim. Must be passed before --dockerized, has no effect if --dockerized is not set.",
     ),
     o(
         "--docker-tty/--docker-no-tty",
         is_eager=True,  # docker options should be processed before anything else
         default=True,
-        help="Controls the allocation of a virtual terminal by passing -t to the Docker or Docker-compatible container engine invocation. Must be passed before --dockerized, has no effect if --dockerized is not set.",
+        help="Controls the allocation of a virtual terminal by passing -t to the Docker-compatible container engine invocation. Must be passed before --dockerized, has no effect if --dockerized is not set.",
     ),
     o(
         "--dockerized",
         default=False,
         is_flag=True,
         is_eager=True,  # ddocker options should be processed before anything else
-        help="Re-invoke using a Docker container. Some caveats apply. Must precede all options except --docker-mount, --docker-tty/--docker-no-tty.",
+        help="Run the remaining flags using a Docker container. Some caveats apply. Must precede all options except --docker-mount, --docker-tty/--docker-no-tty.",
         callback=cli_in_container,
     ),
 )

--- a/openlane/__main__.py
+++ b/openlane/__main__.py
@@ -256,6 +256,7 @@ def cli_in_container(
 
     status = 0
     docker_mounts = list(ctx.params.get("docker_mounts") or ())
+    docker_tty: bool = ctx.params.get("docker_tty")
     pdk_root = ctx.params.get("pdk_root")
     argv = sys.argv[sys.argv.index("--dockerized") + 1 :]
 
@@ -265,13 +266,16 @@ def cli_in_container(
         final_argv = ["openlane"] + argv
         interactive = False
 
+    docker_image = os.getenv("OPENLANE_IMAGE_OVERRIDE", f"ghcr.io/efabless/openlane2:{__version__}")
+
     try:
         status = run_in_container(
-            f"ghcr.io/efabless/openlane2:{__version__}",
+            docker_image,
             final_argv,
             pdk_root=pdk_root,
             other_mounts=docker_mounts,
             interactive=interactive,
+            tty=docker_tty,
         )
     except ValueError as e:
         print(e)
@@ -297,16 +301,22 @@ o = partial(option, show_default=True)
         "-m",
         "docker_mounts",
         multiple=True,
-        is_eager=True,  # docker mount, dockerized should be processed before anything else
+        is_eager=True,  # docker options should be processed before anything else
         default=[],
+        help="Additionally mount this directory in dockerized mode. Can be supplied multiple times to mount multiple directories. Must be passed before --dockerized.",
+    ),
+    o(
+        "--docker-tty/--docker-no-tty",
+        is_eager=True,  # docker options should be processed before anything else
+        default=True,
         help="Additionally mount this directory in dockerized mode. Can be supplied multiple times to mount multiple directories. Must be passed before --dockerized.",
     ),
     o(
         "--dockerized",
         default=False,
         is_flag=True,
-        is_eager=True,  # docker mount, dockerized should be processed before anything else
-        help="Re-invoke using a Docker container. Some caveats apply. Must precede all options except --docker-mount.",
+        is_eager=True,  # ddocker options should be processed before anything else
+        help="Re-invoke using a Docker container. Some caveats apply. Must precede all options except --docker-mount, --docker-tty/--docker-no-tty.",
         callback=cli_in_container,
     ),
     constraint=If(~IsSet("dockerized"), accept_none),
@@ -353,6 +363,7 @@ def cli(ctx, /, **kwargs):
         run_kwargs.update(**{k: kwargs[k] for k in ["pdk_root", "pdk", "scl"]})
 
     for subcommand_flag in [
+        "docker_tty",
         "docker_mounts",
         "dockerized",
         "version",

--- a/openlane/__main__.py
+++ b/openlane/__main__.py
@@ -30,9 +30,6 @@ from cloup import (
     Context,
 )
 from cloup.constraints import (
-    If,
-    IsSet,
-    accept_none,
     mutually_exclusive,
 )
 

--- a/openlane/__main__.py
+++ b/openlane/__main__.py
@@ -256,7 +256,7 @@ def cli_in_container(
 
     status = 0
     docker_mounts = list(ctx.params.get("docker_mounts") or ())
-    docker_tty: bool = ctx.params.get("docker_tty", False)
+    docker_tty: bool = ctx.params.get("docker_tty", True)
     pdk_root = ctx.params.get("pdk_root")
     argv = sys.argv[sys.argv.index("--dockerized") + 1 :]
 
@@ -304,14 +304,14 @@ o = partial(option, show_default=True)
         "docker_mounts",
         multiple=True,
         is_eager=True,  # docker options should be processed before anything else
-        default=[],
-        help="Additionally mount this directory in dockerized mode. Can be supplied multiple times to mount multiple directories. Must be passed before --dockerized.",
+        default=(),
+        help="Additionally mount this directory in dockerized mode. Can be supplied multiple times to mount multiple directories. Must be passed before --dockerized, has no effect if --dockerized is not set.",
     ),
     o(
         "--docker-tty/--docker-no-tty",
         is_eager=True,  # docker options should be processed before anything else
         default=True,
-        help="Additionally mount this directory in dockerized mode. Can be supplied multiple times to mount multiple directories. Must be passed before --dockerized.",
+        help="Controls the allocation of a virtual terminal by passing -t to the Docker or Docker-compatible container engine invocation. Must be passed before --dockerized, has no effect if --dockerized is not set.",
     ),
     o(
         "--dockerized",
@@ -321,7 +321,6 @@ o = partial(option, show_default=True)
         help="Re-invoke using a Docker container. Some caveats apply. Must precede all options except --docker-mount, --docker-tty/--docker-no-tty.",
         callback=cli_in_container,
     ),
-    constraint=If(~IsSet("dockerized"), accept_none),
 )
 @option_group(
     "Subcommands",

--- a/openlane/__version__.py
+++ b/openlane/__version__.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-__version__ = "2.0.0b9"
+__version__ = "2.0.0b10"
 
 if __name__ == "__main__":
     print(__version__, end="")

--- a/openlane/container.py
+++ b/openlane/container.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 
 ## This file is internal to OpenLane 2 and is not part of the API.
-
-from genericpath import isdir
 import os
 import re
 import shlex

--- a/openlane/container.py
+++ b/openlane/container.py
@@ -171,7 +171,7 @@ def run_in_container(
 
     if not ensure_image(image):
         raise ValueError(f"Failed to use image '{image}'.")
-    
+
     terminal_args = []
     if interactive:
         terminal_args.append("-i")

--- a/openlane/container.py
+++ b/openlane/container.py
@@ -154,6 +154,7 @@ def run_in_container(
     scl: Optional[str] = None,
     other_mounts: Optional[Sequence[str]] = None,
     interactive: bool = False,
+    tty: bool = False,
 ) -> int:
     # If imported at the top level, would interfere with Conda where Volare
     # would not be installed.
@@ -170,6 +171,12 @@ def run_in_container(
 
     if not ensure_image(image):
         raise ValueError(f"Failed to use image '{image}'.")
+    
+    terminal_args = []
+    if interactive:
+        terminal_args.append("-i")
+    if tty:
+        terminal_args.append("-t")
 
     mount_args = []
     from_home, to_home = sanitize_path(pathlib.Path.home())
@@ -217,8 +224,8 @@ def run_in_container(
             CONTAINER_ENGINE,
             "run",
             "--rm",
-            "-ti" if interactive else "-t",
         ]
+        + terminal_args
         + permission_args(osinfo)
         + mount_args
         + gui_args(osinfo)


### PR DESCRIPTION
* Add new commandline options: `--docker-tty/--docker-no-tty`, controlling the `-t` flag of Docker and compatible container engines which allocates a virtual tty
* Convert CI to use `--dockerized` instead of a plain `docker run`