### PR TITLE
Fix broken KLayout DRC Report

### DIFF
--- a/openlane/common/drc.py
+++ b/openlane/common/drc.py
@@ -174,7 +174,7 @@ class DRC:
                                 cell = ET.Element("cell")
                                 cell.text = self.module
                                 category = ET.Element("category")
-                                category.text = violation.category_name
+                                category.text = "'" + violation.category_name + "'"
                                 visited = ET.Element("visited")
                                 visited.text = "false"
                                 multiplicity = ET.Element("multiplicity")

--- a/openlane/common/drc.py
+++ b/openlane/common/drc.py
@@ -174,7 +174,7 @@ class DRC:
                                 cell = ET.Element("cell")
                                 cell.text = self.module
                                 category = ET.Element("category")
-                                category.text = "'" + violation.category_name + "'"
+                                category.text = f"'{violation.category_name}'"
                                 visited = ET.Element("visited")
                                 visited.text = "false"
                                 multiplicity = ET.Element("multiplicity")


### PR DESCRIPTION
Loading the drc.klayout.xml in recent KLayout results in an error: 

```
XML parser error: met4.2 is not a valid category path in line 1, column 251
```

Apparently, the category names needs to be surrounded by single quotes. After this fix, KLayout is able to load and show the DRC markers correctly. Verified with KLayout v0.28.10 on Windows 11.