### PR TITLE
Fix broken FP_PDN_CFG

### DIFF
--- a/openlane/scripts/openroad/pdn.tcl
+++ b/openlane/scripts/openroad/pdn.tcl
@@ -15,14 +15,14 @@
 source $::env(SCRIPTS_DIR)/openroad/common/io.tcl
 read_current_odb
 
-if {![info exists ::env(PDN_CFG)]} {
-    set ::env(PDN_CFG) $::env(SCRIPTS_DIR)/openroad/common/pdn_cfg.tcl
+if {![info exists ::env(FP_PDN_CFG)]} {
+    set ::env(FP_PDN_CFG) $::env(SCRIPTS_DIR)/openroad/common/pdn_cfg.tcl
 }
 
 source $::env(SCRIPTS_DIR)/openroad/common/set_power_nets.tcl
 
 # load the grid definitions
-if {[catch {source $::env(PDN_CFG)} errmsg]} {
+if {[catch {source $::env(FP_PDN_CFG)} errmsg]} {
     puts stderr $errmsg
     exit 1
 }


### PR DESCRIPTION
`PDN_CFG` was renamed to `FP_PDN_CFG` in 2.0.0b7. However, it was not renamed in pdn.tcl, so it is no longer possible to define a custom PDN configuration file.

I verified this fix with the Tiny Tapeout multiplexer: before this fix, hardening the mux controller failed with 2.0.0b7 (where as it worked on 2.0.0b6) since the custom PDN script is not loaded (causing the default PDN to be used, which in turn conflicts with some custom routing we have an causes DRC/LVS failures). 

After applying this fix on top of 2.0.0b7, I was able to harden the mux controller successfully and get similar results to the 2.0.0b6.