### PR TITLE
Lint Error on Latch

### DIFF
--- a/.github/test_sets/test_sets.yml
+++ b/.github/test_sets/test_sets.yml
@@ -10,7 +10,10 @@
       config_file: config.tcl
     - usb
     - usb_cdc_core
-    # - manual_macro_placement_test
+    - name: latch
+      config_file: config_good.json
+    - name: latch
+      config_file: config_bad.json
     - spm
     - gcd
     - caravel_upw
@@ -36,6 +39,10 @@
     - usb_cdc_core
     - zipdiv
     - wbqspiflash
+    - name: latch
+      config_file: latch_good.json
+    - name: latch
+      config_file: latch_bad.json
 - scl: gf180mcuD/gf180mcu_fd_sc_mcu7t5v0
   name: extended_test_set
   designs:

--- a/.github/test_sets/test_sets.yml
+++ b/.github/test_sets/test_sets.yml
@@ -40,9 +40,9 @@
     - zipdiv
     - wbqspiflash
     - name: latch
-      config_file: latch_good.json
+      config_file: config_good.json
     - name: latch
-      config_file: latch_bad.json
+      config_file: config_bad.json
 - scl: gf180mcuD/gf180mcu_fd_sc_mcu7t5v0
   name: extended_test_set
   designs:

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ failures_report.json
 .coverage
 htmlcov/
 prof/
+sandbox/

--- a/openlane/scripts/yosys/synthesize.tcl
+++ b/openlane/scripts/yosys/synthesize.tcl
@@ -258,7 +258,6 @@ if { $adder_type == "RCA"} {
     }
 }
 
-# <synth> split to run check -assert in the middle
 hierarchy -check -auto-top
 proc_clean
 proc_rmdead
@@ -267,7 +266,7 @@ proc_init
 proc_arst
 proc_rom
 proc_mux
-proc_dlatch
+tee -o "$report_dir/latch.rpt" proc_dlatch
 proc_dff
 proc_memwr
 proc_clean

--- a/openlane/steps/step.py
+++ b/openlane/steps/step.py
@@ -875,9 +875,10 @@ class Step(ABC):
                 elif not silent and "table template" not in line:  # sky130 ff hack
                     verbose(line.strip())
         returncode = process.wait()
-        split_lines = lines.split("\n")
+        log_file.close()
         if returncode != 0:
             if returncode > 0:
+                split_lines = lines.split("\n")
                 log = "\n".join(split_lines[-10:])
                 if log.strip() != "":
                     err(log)

--- a/openlane/steps/verilator.py
+++ b/openlane/steps/verilator.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 import os
 import re
+import subprocess
 from typing import List, Optional, Tuple
-from subprocess import CalledProcessError
 
 from .step import Step, StepException, ViewsUpdate, MetricsUpdate
 from ..common import DesignFormat
@@ -48,6 +48,12 @@ class Lint(Step):
             "When a file references an include file, resolve the filename relative to the path of the referencing file, instead of relative to the current directory.",
             default=True,
             deprecated_names=["VERILATOR_RELATIVE_INCLUDES"],
+        ),
+        Variable(
+            "LINTER_ERROR_ON_LATCH",
+            bool,
+            "When a latch is inferred by an `always` block that is not explicitly marked as `always_latch`, report this as a linter error.",
+            default=True,
         ),
         Variable(
             "SYNTH_DEFINES",
@@ -112,11 +118,14 @@ class Lint(Step):
         if self.config["LINTER_RELATIVE_INCLUDES"]:
             extra_args.append("--relative-includes")
 
+        if self.config["LINTER_ERROR_ON_LATCH"]:
+            extra_args.append("--Werror-LATCH")
+
         for define in defines:
             extra_args.append(f"+define+{define}")
         extra_args += defines
 
-        exit_error: Optional[CalledProcessError] = None
+        exit_error: Optional[subprocess.CalledProcessError] = None
         try:
             self.run_subprocess(
                 [
@@ -124,6 +133,7 @@ class Lint(Step):
                     "--lint-only",
                     "--Wall",
                     "--Wno-DECLFILENAME",
+                    "--Wno-EOFNEWLINE",
                     "--top-module",
                     self.config["DESIGN_NAME"],
                 ]
@@ -132,36 +142,38 @@ class Lint(Step):
                 + extra_args,
                 env=env,
             )
-        except CalledProcessError as e:
+        except subprocess.CalledProcessError as e:
             exit_error = e
 
         warnings_count = 0
         errors_count = 0
+        latch_count = 0
         timing_constructs = 0
 
-        error_pattern = re.compile(r"\s*\%Error: Exiting due to (\d+) error\(s\)")
-        with open(self.get_log_path(), "r") as f:
-            line = ""
+        exiting_rx = re.compile(r"^\s*%Error: Exiting due to (\d+) error\(s\)")
+        with open(self.get_log_path(), "r", encoding="utf8") as f:
             for line in f:
-                if "%Warning-" in line:
+                line = line.strip()
+                if r"%Warning-" in line:
                     warnings_count += 1
-                if "Error-NEEDTIMINGOPT" in line:
+                if r"%Error-LATCH" in line:
+                    latch_count += 1
+                if r"%Error-NEEDTIMINGOPT" in line:
                     timing_constructs = 1
+                if match := exiting_rx.search(line):
+                    errors_count = int(match[1])
 
-            if exit_error is not None:
-                matched_errors = error_pattern.match(line)
-                if matched_errors:
-                    errors_count = int(matched_errors.group(1))
-                else:
-                    raise StepException(
-                        f"Verilator exited unexpectedly: {exit_error.args}: {exit_error.stdout}"
-                    )
+            if exit_error is not None and errors_count == 0:
+                raise StepException(
+                    f"Verilator exited unexpectedly: Not exiting due to errors"
+                )
 
         metrics_updates.update({"design__lint_errors__count": errors_count})
         metrics_updates.update(
             {"design__lint_timing_constructs__count": timing_constructs}
         )
         metrics_updates.update({"design__lint_warnings__count": warnings_count})
+        metrics_updates.update({"design__latch__count": latch_count})
         return views_updates, metrics_updates
 
     def layout_preview(self) -> Optional[str]:

--- a/openlane/steps/verilator.py
+++ b/openlane/steps/verilator.py
@@ -164,9 +164,7 @@ class Lint(Step):
                     errors_count = int(match[1])
 
             if exit_error is not None and errors_count == 0:
-                raise StepException(
-                    f"Verilator exited unexpectedly: Not exiting due to errors"
-                )
+                raise StepException(f"Verilator exited unexpectedly: {exit_error}")
 
         metrics_updates.update({"design__lint_errors__count": errors_count})
         metrics_updates.update(

--- a/openlane/steps/yosys.py
+++ b/openlane/steps/yosys.py
@@ -30,7 +30,7 @@ from ..common import Path, get_script_dir
 starts_with_whitespace = re.compile(r"^\s+.+$")
 
 
-def parse_yosys_check(
+def _parse_yosys_check(
     report: io.TextIOBase,
     tristate_okay: bool = False,
 ) -> int:
@@ -342,7 +342,7 @@ class Synthesis(YosysStep):
         )
         metric_updates["synthesis__check_error__count"] = 0
         if os.path.exists(check_error_count_file):
-            metric_updates["synthesis__check_error__count"] = parse_yosys_check(
+            metric_updates["synthesis__check_error__count"] = _parse_yosys_check(
                 open(check_error_count_file),
                 self.config["SYNTH_CHECKS_ALLOW_TRISTATE"],
             )


### PR DESCRIPTION
* Added latch design to fastest test set for both supported PDKs
* Latches are now reported as a lint error if the variable `LINTER_ERROR_ON_LATCH` is set to `True` (which it is by default)
* Fixed a race condition with `openlane/steps/step.py::Step::run_subprocess`


---

Resolves #194 