### PR TITLE
Fix log path in `create_blackbox_model`

### DIFF
--- a/openlane/common/toolbox.py
+++ b/openlane/common/toolbox.py
@@ -416,7 +416,7 @@ class Toolbox(object):
         for file in final_files:
             commands += f"read_verilog -sv -lib {file};\n"
 
-        output_log_path = os.path.join(self.tmp_dir, f"{out_path}_yosys.log")
+        output_log_path = f"{out_path}_yosys.log"
         output_log = open(output_log_path, "wb")
         try:
             subprocess.check_call(


### PR DESCRIPTION
`output_log_path` in `toolbox.py` is formed from `self.tmp_dir` and `out_path` (line 419), but `out_path` already includes `self.tmp_dir` (line 379), causing flows to fail:

```
Traceback (most recent call last):
  File "/home/nixos/designs/xspi_os/flow.py", line 33, in <module>
    flow.start()
  File "/nix/store/3ics23fpk3gzby2ys5cm648xgcwfpcch-python3.10-openlane/lib/python3.10/site-packages/openlane/flows/flow.py", line 553, in start
    final_state, step_objects = self.run(
  File "/nix/store/3ics23fpk3gzby2ys5cm648xgcwfpcch-python3.10-openlane/lib/python3.10/site-packages/openlane/flows/sequential.py", line 276, in run
    current_state = step.start(
  File "/nix/store/3ics23fpk3gzby2ys5cm648xgcwfpcch-python3.10-openlane/lib/python3.10/site-packages/openlane/steps/step.py", line 704, in start
    views_updates, metrics_updates = self.run(state_in_result, **kwargs)
  File "/nix/store/3ics23fpk3gzby2ys5cm648xgcwfpcch-python3.10-openlane/lib/python3.10/site-packages/openlane/steps/verilator.py", line 96, in run
    bb_path = self.toolbox.create_blackbox_model(
  File "/nix/store/3ics23fpk3gzby2ys5cm648xgcwfpcch-python3.10-openlane/lib/python3.10/site-packages/openlane/common/toolbox.py", line 420, in create_blackbox_model
    output_log = open(output_log_path, "wb")
FileNotFoundError: [Errno 2] No such file or directory: './runs/RUN_2023-09-26_12-52-06/tmp/./runs/RUN_2023-09-26_12-52-06/tmp/cf02caa1b389480a9e0cd34e91bb063d.bb.v_yosys.log'
```

https://github.com/efabless/openlane2/blob/fbbe66691c281da8b39eb74bbf83309959477d8a/openlane/common/toolbox.py#L379
https://github.com/efabless/openlane2/blob/fbbe66691c281da8b39eb74bbf83309959477d8a/openlane/common/toolbox.py#L419-L420