### PR TITLE
Chomp underscores in corner patterns + Make shell.nix accept plugins

### DIFF
--- a/openlane/steps/openroad.py
+++ b/openlane/steps/openroad.py
@@ -1111,7 +1111,7 @@ class RCX(OpenROADStep):
                 )
                 return None
 
-            corner_sanitized = corner.strip("*")
+            corner_sanitized = corner.strip("*_")
             corner_dir = os.path.join(self.step_dir, corner_sanitized)
             mkdirp(corner_dir)
 

--- a/shell.nix
+++ b/shell.nix
@@ -13,7 +13,10 @@
 # limitations under the License.
 {
     pkgs ? import ./nix/pkgs.nix {},
-    openlane ? import ./. { inherit pkgs; }
+    openlane ? import ./. { inherit pkgs; },
+
+    extras ? [],
+    python-extras ? [],
 }:
 
 with pkgs; mkShell {
@@ -37,5 +40,5 @@ with pkgs; mkShell {
     # Docs + Testing
     jupyter
     graphviz
-  ] ++ openlane.includedTools;
+  ] ++ openlane.includedTools ++ extras;
 }

--- a/shell.nix
+++ b/shell.nix
@@ -12,14 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 {
-    pkgs ? import ./nix/pkgs.nix {},
-    openlane ? import ./. { inherit pkgs; },
-
-    extras ? [],
-    python-extras ? [],
+  pkgs ? import ./nix/pkgs.nix {},
+  openlane ? import ./. { inherit pkgs; },
+  openlane-plugins ? [],
 }:
 
-with pkgs; mkShell {
+with pkgs; let
+  pluginIncludedTools = lib.lists.flatten (map (n: n.includedTools) openlane-plugins)
+  
+; in mkShell {
   name = "openlane-shell";
 
   propagatedBuildInputs = [
@@ -27,7 +28,7 @@ with pkgs; mkShell {
       openlane
       pyfakefs
       pytest
-    ]))
+    ] ++ openlane-plugins ))
 
     # Conveniences
     git
@@ -40,5 +41,5 @@ with pkgs; mkShell {
     # Docs + Testing
     jupyter
     graphviz
-  ] ++ openlane.includedTools ++ extras;
+  ] ++ openlane.includedTools ++ pluginIncludedTools;
 }


### PR DESCRIPTION
* Strips `_` alongside asterisks from corner names, which without that, files intended for corner patterns such as `max_*` would have the name `max_`
* Allows OpenLane plugins to be passed to `shell.nix` so plugins can reuse the `shell.nix` internally