### PR TITLE
Add support for more SystemVerilog language features using Synlig

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ logs/
 /openlane_run
 failures_report.json
 abc.history
+slpp_all/
 
 # Testing
 .coverage

--- a/default.nix
+++ b/default.nix
@@ -25,11 +25,12 @@
   openroad ? pkgs.libsForQt5.callPackage ./nix/openroad.nix {
     inherit pkgs;
   },
+  surelog ? import ./nix/surelog.nix { inherit pkgs; },
   verilator ? import ./nix/verilator.nix { inherit pkgs; },
   volare ? import ./nix/volare.nix { inherit pkgs; },
   yosys ? import ./nix/yosys.nix { inherit pkgs; },
 
-  synlig-sv ? import ./nix/yosys-synlig-sv.nix { inherit pkgs; inherit yosys; },
+  synlig-sv ? import ./nix/yosys-synlig-sv.nix { inherit pkgs; inherit yosys; inherit surelog; },
   lighter ? import ./nix/yosys-lighter.nix { inherit pkgs; inherit yosys; },
   sby ? import ./nix/yosys-sby.nix { inherit pkgs; inherit yosys; },
   eqy ? import ./nix/yosys-eqy.nix { inherit pkgs; inherit yosys; inherit sby; },
@@ -64,7 +65,7 @@ with pkgs; with python3.pkgs; buildPythonPackage rec {
     verilog
     verilator
     tcl
-    uhdm
+    surelog
   ];
 
   propagatedBuildInputs = [

--- a/default.nix
+++ b/default.nix
@@ -29,6 +29,7 @@
   volare ? import ./nix/volare.nix { inherit pkgs; },
   yosys ? import ./nix/yosys.nix { inherit pkgs; },
 
+  synlig-sv ? import ./nix/yosys-synlig-sv.nix { inherit pkgs; inherit yosys; },
   lighter ? import ./nix/yosys-lighter.nix { inherit pkgs; inherit yosys; },
   sby ? import ./nix/yosys-sby.nix { inherit pkgs; inherit yosys; },
   eqy ? import ./nix/yosys-eqy.nix { inherit pkgs; inherit yosys; inherit sby; },
@@ -53,6 +54,7 @@ with pkgs; with python3.pkgs; buildPythonPackage rec {
       sby
       eqy
       lighter
+      synlig-sv
       ys-ghdl
     ]))
     openroad
@@ -62,6 +64,7 @@ with pkgs; with python3.pkgs; buildPythonPackage rec {
     verilog
     verilator
     tcl
+    uhdm
   ];
 
   propagatedBuildInputs = [

--- a/nix/openroad.nix
+++ b/nix/openroad.nix
@@ -19,7 +19,7 @@
 with pkgs; let
   abc = import ./openroad-abc.nix { inherit pkgs; };
   or-tools = import ./or-tools.nix { inherit pkgs; };
-  lemon = lemon-graph.overrideAttrs (finalAttrs: previousAttrs: {
+  lemon-graph' = lemon-graph.overrideAttrs (finalAttrs: previousAttrs: {
     meta = {
       broken = false;
     };
@@ -77,7 +77,7 @@ in clangStdenv.mkDerivation rec {
     clp
     cbc
     
-    lemon
+    lemon-graph'
   ];
 
   nativeBuildInputs = [

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -11,15 +11,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-args: import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/0218941ea68b4c625533bead7bbb94ccce52dceb.tar.gz") {
+
+let
+    newpkgs = import (
+    fetchTarball "https://github.com/NixOS/nixpkgs/archive/3b79cc4bcd9c09b5aa68ea1957c25e437dc6bc58.tar.gz"
+    ) {};
+in args: import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/0218941ea68b4c625533bead7bbb94ccce52dceb.tar.gz") {
     overlays = [
         (new: old: {
             # HACK BECAUSE THIS IS BROKEN ON MAC ON THE COMMIT WE'RE USING
-            ghdl-llvm = if old.stdenv.isDarwin then (
-                import (
-                    fetchTarball "https://github.com/NixOS/nixpkgs/archive/3b79cc4bcd9c09b5aa68ea1957c25e437dc6bc58.tar.gz"
-                ) {}
-            ).ghdl-llvm.overrideAttrs (finalAttrs: previousAttrs: {
+            ghdl-llvm = if old.stdenv.isDarwin then newpkgs.ghdl-llvm.overrideAttrs (finalAttrs: previousAttrs: {
                 meta = {
                     platforms = previousAttrs.meta.platforms ++ old.lib.platforms.darwin;
                 };

--- a/nix/surelog.nix
+++ b/nix/surelog.nix
@@ -43,7 +43,7 @@ with pkgs; let
             owner = "chipsalliance";
             repo = "uhdm";
             rev = "v${version}";
-            hash = "sha256-IwK42rDTUYS4gFUkpz9e7tYRg82LBN6xXY5OEY9Pk+Q=";
+            hash = "sha256-Q/u5lvILYDT5iScES3CTPIm/B5apoOHXOQmCsZ73NlU=";
         };
         patches = [];
         doCheck = false;

--- a/nix/yosys-synlig-sv.nix
+++ b/nix/yosys-synlig-sv.nix
@@ -14,11 +14,10 @@
 {
   pkgs ? import ./pkgs.nix {},
   yosys ? import ./yosys.nix { inherit pkgs; },
+  surelog ? import ./surelog.nix { inherit pkgs; },
 }:
 
-with pkgs; let
-    surelog = import ./surelog.nix { inherit pkgs; };
-in clangStdenv.mkDerivation rec {
+with pkgs; clangStdenv.mkDerivation rec {
   name = "yosys-synlig-sv";
   dylibs = ["synlig-sv"];
 

--- a/nix/yosys-synlig-sv.nix
+++ b/nix/yosys-synlig-sv.nix
@@ -47,7 +47,6 @@ in clangStdenv.mkDerivation rec {
   buildInputs = [
     yosys.py3
     surelog
-    surelog.uhdm'
     capnproto
     antlr4.runtime.cpp
   ];

--- a/nix/yosys-synlig-sv.nix
+++ b/nix/yosys-synlig-sv.nix
@@ -1,0 +1,86 @@
+# Copyright 2023 Efabless Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+{
+  pkgs ? import ./pkgs.nix {},
+  yosys ? import ./yosys.nix { inherit pkgs; },
+}:
+
+with pkgs; let
+    surelog = import ./surelog.nix { inherit pkgs; };
+in clangStdenv.mkDerivation rec {
+  name = "yosys-synlig";
+  dylibs = ["synlig-sv"];
+
+  full-src = fetchFromGitHub {
+    owner = "chipsalliance";
+    repo = "synlig";
+    rev = "e41b39653b5bc45f464825affa5464473be7b92a";
+    sha256 = "sha256-2KM7JZhfHfNPu9LtLsoN7e3q+U32p+ybL36y9ae/wdU=";
+  };
+
+  src = "${full-src}/frontends/systemverilog";
+
+  makeFlags = [
+    "YOSYS_CONFIG=${yosys}/bin/yosys-config"
+  ];
+
+  propagatedBuildInputs = [
+    yosys
+    libedit
+    libbsd
+    zlib
+  ];
+
+  buildInputs = [
+    yosys.py3
+    cmake
+    surelog
+    surelog.uhdm'
+    capnproto
+  ];
+
+  buildPhase = ''
+  set -x
+  yosys-config --build synlig-sv.so\
+    --std=c++17\
+    -I${full-src}/third_party/yosys_mod\
+    *.cc\
+    ${surelog.uhdm'}/lib/*.a\
+    ${capnproto}/lib/*.a
+  '';
+
+  installPhase = ''
+  mkdir -p $out/share/yosys/plugins
+  cp synlig-sv.so $out/share/yosys/plugins/synlig-sv.so
+  '';
+
+  dontUseCmakeConfigure = true;
+
+#   preConfigure = ''
+#   sed -i.bak "s@/usr/local@$out@" Makefile
+#   sed -i.bak "s@#!/usr/bin/env python3@#!${yosys.py3}/bin/python3@" sbysrc/sby.py
+#   sed -i.bak "s@\"/usr/bin/env\", @@" sbysrc/sby_core.py
+#   '';
+
+#   checkPhase = ''
+#   make test
+#   '';
+
+#   doCheck = false;
+
+  computed_PATH = lib.makeBinPath propagatedBuildInputs;
+  makeWrapperArgs = [
+    "--prefix PATH : ${computed_PATH}"
+  ];
+}

--- a/nix/yosys.nix
+++ b/nix/yosys.nix
@@ -65,8 +65,8 @@ in clangStdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "YosysHQ";
     repo = "yosys";
-    rev = "2584903a0605cc7ffdfc1996254ccc1f548403f2";
-    sha256 = "sha256-3MsWF161pqqeAbmeTlkQY6UpU4pq1WT0XXK9yciwt0M=";
+    rev = "daad9ede0137dc58487a0abc126253e671a85b14";
+    sha256 = "sha256-GHDsMBj7DRb9ffESgzd1HzDAA6Cyft5PomidvIMzn9g=";
   };
 
   nativeBuildInputs = [ pkg-config bison flex ];

--- a/openlane/scripts/yosys/common.tcl
+++ b/openlane/scripts/yosys/common.tcl
@@ -66,3 +66,30 @@ proc read_deps {{power_defines "off"}} {
         }
     }
 }
+
+proc read_verilog_files {} {
+    set verilog_include_args [list]
+    if {[info exist ::env(VERILOG_INCLUDE_DIRS)]} {
+        foreach dir $::env(VERILOG_INCLUDE_DIRS) {
+            lappend verilog_include_args "-I$dir"
+        }
+    }
+
+    set synlig_defer [list]
+    if { $::env(SYNLIG_DEFER) } {
+        lappend synlig_defer -defer
+    }
+
+    if { $::env(USE_SYNLIG) && $::env(SYNLIG_DEFER) } {
+        foreach file $::env(VERILOG_FILES) {
+            read_systemverilog -defer -sv {*}$verilog_include_args $file
+        }
+        read_systemverilog -link -top $::env(DESIGN_NAME)
+    } elseif { $::env(USE_SYNLIG) } {
+        read_systemverilog -top $::env(DESIGN_NAME) -sv {*}$verilog_include_args {*}$::env(VERILOG_FILES)
+    } else {
+        foreach file $::env(VERILOG_FILES) {
+            read_verilog -sv {*}$verilog_include_args $file
+        }
+    }
+}

--- a/openlane/scripts/yosys/json_header.tcl
+++ b/openlane/scripts/yosys/json_header.tcl
@@ -17,15 +17,7 @@ set vtop $::env(DESIGN_NAME)
 
 read_deps "on"
 
-set verilog_include_args [list]
-if {[info exist ::env(VERILOG_INCLUDE_DIRS)]} {
-    foreach dir $::env(VERILOG_INCLUDE_DIRS) {
-        lappend verilog_include_args "-I$dir"
-    }
-}
-foreach file $::env(VERILOG_FILES) {
-    read_verilog -sv {*}$verilog_include_args $file
-}
+read_verilog_files
 
 if { [info exists ::env(SYNTH_PARAMETERS) ] } {
     foreach define $::env(SYNTH_PARAMETERS) {

--- a/openlane/scripts/yosys/synthesize.tcl
+++ b/openlane/scripts/yosys/synthesize.tcl
@@ -197,18 +197,8 @@ if { !($adder_type in [list "YOSYS" "FA" "RCA" "CSA"]) } {
 
 # Start Synthesis
 if { [info exists ::env(VERILOG_FILES) ]} {
-    set verilog_include_args [list]
-    if {[info exist ::env(VERILOG_INCLUDE_DIRS)]} {
-        foreach dir $::env(VERILOG_INCLUDE_DIRS) {
-            lappend verilog_include_args "-I$dir"
-        }
-    }
-
-    foreach file $::env(VERILOG_FILES) {
-        read_verilog -sv {*}$verilog_include_args $file
-    }
+    read_verilog_files
 } elseif { [info exists ::env(VHDL_FILES)] } {
-    puts $::env(VHDL_FILES)
     ghdl {*}$::env(VHDL_FILES) -e $::env(DESIGN_NAME)
 } else {
     puts "SCRIPT NOT CALLED CORRECTLY: EITHER VERILOG_FILES OR VHDL_FILES MUST BE SET"

--- a/openlane/steps/yosys.py
+++ b/openlane/steps/yosys.py
@@ -84,6 +84,18 @@ verilog_rtl_cfg_vars = [
         Optional[List[str]],
         "Specifies the Verilog `include` directories.",
     ),
+    Variable(
+        "USE_SYNLIG",
+        bool,
+        "Use the Synlig plugin to process files, which has greater SystemVerilog parsing capabilities, but may not support all Yosys commands properly.",
+        default=True,
+    ),
+    Variable(
+        "SYNLIG_DEFER",
+        bool,
+        "Uses -defer flag when reading files the Synlig plugin, which may improve performance by reading each file separately, but is experimental.",
+        default=False,
+    )
 ]
 
 
@@ -138,7 +150,7 @@ class YosysStep(TclStep):
         Variable(
             "USE_LIGHTER",
             bool,
-            "Activates Lighter, an experimental module that attempts to optimize clock-gated flip-flops.",
+            "Activates Lighter, an experimental plugin that attempts to optimize clock-gated flip-flops.",
             default=False,
         ),
         Variable(


### PR DESCRIPTION
* Added [Surelog](https://github.com/chipsalliance/surelog)
* Added the [Synlig Yosys SystemVerilog Plugin] (https://github.com/chipsalliance/synlig)
* Some internal restructuring of the underlying Nix code
* Updated Yosys to `0.34`/`daad9ed`
* Updated implementation of `Yosys.Synthesis `to support Synlig
  * New variable, `USE_SYNLIG`, enables the use of the Synlig frontend in place of Yosys's Verilog frontend (enabled by default)
  * New variable, `SYNLIG_DEFER`, enables the experimental `-defer` feature (disabled by default)