### PR TITLE
Capture errors generated by Magic

### DIFF
--- a/openlane/steps/magic.py
+++ b/openlane/steps/magic.py
@@ -123,7 +123,7 @@ class MagicStep(TclStep):
         error_patterns = [
             r"DEF read.*\(Error\).*",
             r"LEF read.*\(Error\).*",
-            r"Error while reading cell.*",
+            r"Error while reading cell(?!.*Warning:).*",
         ]
 
         error_found = False

--- a/openlane/steps/magic.py
+++ b/openlane/steps/magic.py
@@ -138,16 +138,12 @@ class MagicStep(TclStep):
                 r".*is an abstract view.*",
             ]
 
-            error_found = False
             for line in open(self.get_log_path(), encoding="utf8"):
                 for pattern in error_patterns:
                     if re.match(pattern, line):
-                        error_found = True
-                        break
-                if error_found is True:
-                    raise StepError(
-                        f"Error encountered during running Magic.\nError: {line}Check the log file of {self.id}."
-                    )
+                        raise StepError(
+                            f"Error encountered during running Magic.\nError: {line}Check the log file of {self.id}."
+                        )
 
         return views_updates, metrics_updates
 

--- a/openlane/steps/magic.py
+++ b/openlane/steps/magic.py
@@ -124,14 +124,12 @@ class MagicStep(TclStep):
             r"DEF read.*\(Error\).*",
             r"LEF read.*\(Error\).*",
             r"Error while reading cell(?!.*Warning:).*",
+            r".*Calma output error.*",
+            r".*is an abstract view.*",
         ]
 
         error_found = False
         for line in open(self.get_log_path(), encoding="utf8"):
-            if "Calma output error" in line:
-                error_found = True
-            elif "is an abstract view" in line:
-                error_found = True
             for pattern in error_patterns:
                 if re.match(pattern, line):
                     error_found = True

--- a/openlane/steps/magic.py
+++ b/openlane/steps/magic.py
@@ -126,20 +126,20 @@ class MagicStep(TclStep):
             r"Error while reading cell.*",
         ]
 
+        error_found = False
         for line in open(self.get_log_path(), encoding="utf8"):
             if "Calma output error" in line:
-                raise StepError(
-                    f"Magic GDS was written with errors. Check log file of {self.id}"
-                )
+                error_found = True
             elif "is an abstract view" in line:
-                raise StepError(
-                    f"Missing GDS view for a macro. Check log file of {self.id}."
-                )
+                error_found = True
             for pattern in error_patterns:
                 if re.match(pattern, line):
-                    raise StepError(
-                        f"Error encountered during running Magic.\nError: {line}Check the log file of {self.id}."
-                    )
+                    error_found = True
+                    break
+            if error_found is True:
+                raise StepError(
+                    f"Error encountered during running Magic.\nError: {line}Check the log file of {self.id}."
+                )
 
         return views_updates, metrics_updates
 

--- a/openlane/steps/magic.py
+++ b/openlane/steps/magic.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
+import re
 import shutil
 from abc import abstractmethod
 from typing import Literal, List, Optional, Tuple
@@ -113,7 +114,34 @@ class MagicStep(TclStep):
         for gds in self.toolbox.get_macro_views(self.config, DesignFormat.GDS):
             env["MACRO_GDS_FILES"] += f" {gds}"
 
-        return super().run(state_in, env=env, **kwargs)
+        views_updates, metrics_updates = super().run(
+            state_in,
+            env=env,
+            **kwargs,
+        )
+
+        error_patterns = [
+            r"DEF read.*\(Error\).*",
+            r"LEF read.*\(Error\).*",
+            r"Error while reading cell.*",
+        ]
+
+        for line in open(self.get_log_path(), encoding="utf8"):
+            if "Calma output error" in line:
+                raise StepError(
+                    f"Magic GDS was written with errors. Check log file of {self.id}"
+                )
+            elif "is an abstract view" in line:
+                raise StepError(
+                    f"Missing GDS view for a macro. Check log file of {self.id}."
+                )
+            for pattern in error_patterns:
+                if re.match(pattern, line):
+                    raise StepError(
+                        f"Error encountered during running Magic.\nError: {line}Check the log file of {self.id}."
+                    )
+
+        return views_updates, metrics_updates
 
 
 @Step.factory.register()
@@ -208,7 +236,6 @@ class StreamOut(MagicStep):
             env["DIE_AREA"] = die_area
 
         env["MAGTYPE"] = "mag"
-        magic_log_dir = os.path.join(self.step_dir, "magic.log")
 
         if self.config["MACROS"] is not None:
             macro_gds = []
@@ -223,7 +250,6 @@ class StreamOut(MagicStep):
         views_updates, metrics_updates = super().run(
             state_in,
             env=env,
-            log_to=magic_log_dir,
             **kwargs,
         )
 
@@ -236,12 +262,6 @@ class StreamOut(MagicStep):
         views_updates[DesignFormat.MAG] = Path(
             os.path.join(self.step_dir, f"{self.config['DESIGN_NAME']}.mag")
         )
-
-        for line in open(magic_log_dir, encoding="utf8"):
-            if "Calma output error" in line:
-                raise StepError("Magic GDS was written with errors.")
-            elif "is an abstract view" in line:
-                raise StepError("Missing GDS view for a macro. Check step log file.")
 
         return views_updates, metrics_updates
 


### PR DESCRIPTION
Add `MAGIC_CAPTURE_ERRORS` to capture and throw errors generated by Magic.

---

Fixes https://github.com/efabless/openlane2/issues/239
Fixes https://github.com/efabless/openlane2/issues/238
Fixes https://github.com/efabless/openlane2/issues/237