### PR TITLE
Allow explicit declaration of double-height rows during floorplanning

### DIFF
--- a/docs/source/usage/migration/variables.md
+++ b/docs/source/usage/migration/variables.md
@@ -14,7 +14,7 @@ variables in this manner:
 
 ```json
 {
-    "VERILOG_FILES_BLACKBOX": ["dir::macros/spm/nl/spm.nl.v"],
+    "EXTRA_VERILOG_MODELS": ["dir::macros/spm/nl/spm.nl.v"],
     "EXTRA_GDS_FILES": ["dir::macros/gds/spm.gds"],
     "EXTRA_LEFS": ["dir::macros/lef/spm.lef"],
     "EXTRA_SPEFS": ["dir::macros/spm/spef/nom_/spm.nom.spef"],

--- a/docs/source/usage/migration/variables.md
+++ b/docs/source/usage/migration/variables.md
@@ -14,7 +14,7 @@ variables in this manner:
 
 ```json
 {
-    "EXTRA_VERILOG_MODELS": ["dir::macros/spm/nl/spm.nl.v"],
+    "VERILOG_FILES_BLACKBOX": ["dir::macros/spm/nl/spm.nl.v"],
     "EXTRA_GDS_FILES": ["dir::macros/gds/spm.gds"],
     "EXTRA_LEFS": ["dir::macros/lef/spm.lef"],
     "EXTRA_SPEFS": ["dir::macros/spm/spef/nom_/spm.nom.spef"],

--- a/openlane/config/flow.py
+++ b/openlane/config/flow.py
@@ -365,7 +365,7 @@ scl_variables = [
     Variable(
         "PLACE_SITE",
         str,
-        "Defines the main placement site in placement as specified in the technology LEF files, to generate the placement grid.",
+        "Defines the primary placement site in placement as specified in the technology LEF files, to generate the placement grid.",
         pdk=True,
     ),
     Variable(

--- a/openlane/config/flow.py
+++ b/openlane/config/flow.py
@@ -369,20 +369,6 @@ scl_variables = [
         pdk=True,
     ),
     Variable(
-        "PLACE_SITE_WIDTH",
-        Decimal,
-        "The site width for the previously designated place site.",
-        units="µm",
-        pdk=True,
-    ),
-    Variable(
-        "PLACE_SITE_HEIGHT",
-        Decimal,
-        "The site height for the previously designated place site.",
-        units="µm",
-        pdk=True,
-    ),
-    Variable(
         "GPL_CELL_PADDING",
         Decimal,
         "Cell padding value (in sites) for global placement. The number will be integer divided by 2 and placed on both sides.",

--- a/openlane/config/removals.py
+++ b/openlane/config/removals.py
@@ -34,4 +34,6 @@ removed_variables: Dict[str, str] = {
     "SYNTH_READ_BLACKBOX_LIB": "Changed to always be on.",
     "CTS_TOLERANCE": "No longer supported by OpenROAD.",
     "MAGIC_GDS_ALLOW_ABSTRACT": "Bad practice. If an abstract view is needed, a GDS file can be generated from the abstract LEF file.",
+    "PLACE_SITE_HEIGHT": "Now automatically extracted from PLACE_SITE.",
+    "PLACE_SITE_WIDTH": "Now automatically extracted from PLACE_SITE."
 }

--- a/openlane/config/removals.py
+++ b/openlane/config/removals.py
@@ -35,5 +35,5 @@ removed_variables: Dict[str, str] = {
     "CTS_TOLERANCE": "No longer supported by OpenROAD.",
     "MAGIC_GDS_ALLOW_ABSTRACT": "Bad practice. If an abstract view is needed, a GDS file can be generated from the abstract LEF file.",
     "PLACE_SITE_HEIGHT": "Now automatically extracted from PLACE_SITE.",
-    "PLACE_SITE_WIDTH": "Now automatically extracted from PLACE_SITE."
+    "PLACE_SITE_WIDTH": "Now automatically extracted from PLACE_SITE.",
 }

--- a/openlane/scripts/openroad/floorplan.tcl
+++ b/openlane/scripts/openroad/floorplan.tcl
@@ -16,20 +16,39 @@ read_pnr_libs
 read_lefs
 read_current_netlist
 
-set ::chip [[::ord::get_db] getChip]
-set ::tech [[::ord::get_db] getTech]
+set ::db [::ord::get_db]
+set ::chip [$::db getChip]
+set ::tech [$::db getTech]
 set ::block [$::chip getBlock]
-set ::dbu [$tech getDbUnitsPerMicron]
+set ::dbu [$::tech getDbUnitsPerMicron]
+set ::libs [$::db getLibs]
+
+foreach lib $::libs {
+    set current_sites [$lib getSites]
+    foreach site $current_sites {
+        set name [$site getName]
+        set ::sites($name) $site
+    }
+}
+
+set ::default_site $::sites($::env(PLACE_SITE))
+
+set ::default_site_height [expr [$::default_site getHeight] / $::dbu]
+set ::default_site_width [expr [$::default_site getWidth] / $::dbu]
 
 unset_propagated_clock [all_clocks]
 
-set bottom_margin  [expr $::env(PLACE_SITE_HEIGHT) * $::env(BOTTOM_MARGIN_MULT)]
-set top_margin  [expr $::env(PLACE_SITE_HEIGHT) * $::env(TOP_MARGIN_MULT)]
-set left_margin [expr $::env(PLACE_SITE_WIDTH) * $::env(LEFT_MARGIN_MULT)]
-set right_margin [expr $::env(PLACE_SITE_WIDTH) * $::env(RIGHT_MARGIN_MULT)]
+set bottom_margin  [expr $::default_site_height * $::env(BOTTOM_MARGIN_MULT)]
+set top_margin  [expr $::default_site_height * $::env(TOP_MARGIN_MULT)]
+set left_margin [expr $::default_site_width * $::env(LEFT_MARGIN_MULT)]
+set right_margin [expr $::default_site_width * $::env(RIGHT_MARGIN_MULT)]
 
 set arg_list [list]
-lappend arg_list -site $::env(PLACE_SITE)
+if { [info exists ::env(EXTRA_SITES)] } {
+    foreach site $::env(EXTRA_SITES) {
+        lappend arg_list -site $site
+    }
+}
 
 if {$::env(FP_SIZING) == "absolute"} {
     if { [llength $::env(DIE_AREA)] != 4 } {

--- a/openlane/scripts/openroad/floorplan.tcl
+++ b/openlane/scripts/openroad/floorplan.tcl
@@ -45,13 +45,16 @@ set top_margin  [expr $::default_site_height * $::env(TOP_MARGIN_MULT)]
 set left_margin [expr $::default_site_width * $::env(LEFT_MARGIN_MULT)]
 set right_margin [expr $::default_site_width * $::env(RIGHT_MARGIN_MULT)]
 
-set arg_list [list]
-lappend arg_list -site $::env(PLACE_SITE)
+set used_sites [list]
+lappend used_sites $::env(PLACE_SITE)
 if { [info exists ::env(EXTRA_SITES)] } {
     foreach site $::env(EXTRA_SITES) {
-        lappend arg_list -site $site
+        lappend used_sites $site
     }
 }
+
+set arg_list [list]
+lappend arg_list -sites "$used_sites"
 
 if {$::env(FP_SIZING) == "absolute"} {
     if { [llength $::env(DIE_AREA)] != 4 } {

--- a/openlane/scripts/openroad/floorplan.tcl
+++ b/openlane/scripts/openroad/floorplan.tcl
@@ -33,8 +33,10 @@ foreach lib $::libs {
 
 set ::default_site $::sites($::env(PLACE_SITE))
 
-set ::default_site_height [expr [$::default_site getHeight] / $::dbu]
-set ::default_site_width [expr [$::default_site getWidth] / $::dbu]
+set ::default_site_height [expr [$::default_site getHeight] / double($::dbu)]
+set ::default_site_width [expr [$::default_site getWidth] / double($::dbu)]
+
+puts "Using site height: $::default_site_height and site width: $::default_site_width…"
 
 unset_propagated_clock [all_clocks]
 

--- a/openlane/scripts/openroad/floorplan.tcl
+++ b/openlane/scripts/openroad/floorplan.tcl
@@ -44,6 +44,7 @@ set left_margin [expr $::default_site_width * $::env(LEFT_MARGIN_MULT)]
 set right_margin [expr $::default_site_width * $::env(RIGHT_MARGIN_MULT)]
 
 set arg_list [list]
+lappend arg_list -site $::env(PLACE_SITE)
 if { [info exists ::env(EXTRA_SITES)] } {
     foreach site $::env(EXTRA_SITES) {
         lappend arg_list -site $site
@@ -77,7 +78,6 @@ if {$::env(FP_SIZING) == "absolute"} {
 
     lappend arg_list -die_area $::env(DIE_AREA)
     lappend arg_list -core_area $::env(CORE_AREA)
-    lappend arg_list -site $::env(PLACE_SITE)
 } else {
     lappend arg_list -utilization $::env(FP_CORE_UTIL)
     lappend arg_list -aspect_ratio $::env(FP_ASPECT_RATIO)

--- a/openlane/steps/openroad.py
+++ b/openlane/steps/openroad.py
@@ -656,7 +656,7 @@ class Floorplan(OpenROADStep):
         Variable(
             "EXTRA_SITES",
             Optional[List[str]],
-            "Extra sites to create rows for. The rows will overlap with the rows for `PLACE_SITE`.",
+            "Explicitly specify sites other than `PLACE_SITE` to create rows for. If the alternate-site standard cells properly declare the `SITE` property, you do not need to provide this explicitly.",
             pdk=True,
         ),
     ]

--- a/openlane/steps/openroad.py
+++ b/openlane/steps/openroad.py
@@ -657,6 +657,7 @@ class Floorplan(OpenROADStep):
             "EXTRA_SITES",
             Optional[List[str]],
             "Extra sites to create rows for. The rows will overlap with the rows for `PLACE_SITE`.",
+            pdk=True,
         ),
     ]
 

--- a/openlane/steps/openroad.py
+++ b/openlane/steps/openroad.py
@@ -653,6 +653,11 @@ class Floorplan(OpenROADStep):
             "The core margin, in multiples of site widths, from the right boundary. If `FP_SIZING` is absolute and `CORE_AREA` is set, this variable has no effect.",
             default=12,
         ),
+        Variable(
+            "EXTRA_SITES",
+            Optional[List[str]],
+            "Extra sites to create rows for. The rows will overlap with the rows for `PLACE_SITE`.",
+        ),
     ]
 
     def get_script_path(self):
@@ -1332,6 +1337,7 @@ class IRDropReport(OpenROADStep):
 
 
 # Resizer Steps
+
 
 ## ABC
 class ResizerStep(OpenROADStep):

--- a/shell.nix
+++ b/shell.nix
@@ -35,6 +35,7 @@ with pkgs; let
     git
     zsh
     delta
+    jdupes
     neovim
     gtkwave
     coreutils


### PR DESCRIPTION
* `OpenROAD.Floorplan`
  * Added a new PDK variable, `EXTRA_SITES`, which specifies alternative sites to use for floorplanning (as overlapping rows) even when:
    * Cells without double-heights are not used
    * Double-height cells with missing or mislabeled LEF `SITE`s are used
* Removed `PLACE_SITE_HEIGHT` and `PLACE_SITE_WIDTH`: can be extracted via OpenROAD

---

Resolves #243 
Depends on https://github.com/efabless/openlane2-ci-designs/pull/6
Depends on https://github.com/efabless/openlane2-step-unit-tests/pull/10