### PR TITLE
Re-add manual macro placement test to CI

### DIFF
--- a/.github/test_sets/test_sets.yml
+++ b/.github/test_sets/test_sets.yml
@@ -20,6 +20,7 @@
     - caravel_upw
     - io_placer
     - test_sram_macro
+    - manual_macro_placement_test
 - scl: sky130A/sky130_fd_sc_hd
   name: extended_test_set
   designs:


### PR DESCRIPTION
* Re-adds manual macro placement test to CI now that the DRC issues have been addressed

---
Depends on https://github.com/efabless/openlane2-ci-designs/pull/7