### PR TITLE
`Magic.StreamOut`: Fix Black-Boxed Macros with non-`N` orientations

### DIFF
--- a/openlane/scripts/magic/common/read.tcl
+++ b/openlane/scripts/magic/common/read.tcl
@@ -68,7 +68,7 @@ proc read_extra_gds {} {
 
 proc read_macro_gds_blackbox {} {
     if { [info exists ::env(__MACRO_GDS)] } {
-        foreach macro [split $::env(__MACRO_GDS) ,] {
+        foreach macro $::env(__MACRO_GDS) {
             set macro_name [lindex $macro 0]
             set gds_file [lindex $macro 1]
             set bbox [lindex $macro 2]

--- a/openlane/scripts/magic/common/read.tcl
+++ b/openlane/scripts/magic/common/read.tcl
@@ -69,17 +69,16 @@ proc read_extra_gds {} {
 proc read_macro_gds_blackbox {} {
     if { [info exists ::env(__MACRO_GDS)] } {
         foreach macro [split $::env(__MACRO_GDS) ,] {
-            if { [llength $macro] > 2 } {
-                puts "Error: Multiple GDS files per macro isn't supported by magic."
-            } else {
-                set macro_name [lindex $macro 0]
-                set gds_file [lindex $macro 1]
-                load $macro_name
-                property LEFview true
-                property GDS_FILE $gds_file
-                property GDS_START 0
-                puts "> set GDS_FILE of $macro_name to $gds_file"
-            }
+            set macro_name [lindex $macro 0]
+            set gds_file [lindex $macro 1]
+            set bbox [lindex $macro 2]
+            load $macro_name
+            property LEFview true
+            property GDS_FILE $gds_file
+            property GDS_START 0
+            property FIXED_BBOX "$bbox"
+            puts "[property]"
+            puts "> set GDS_FILE of $macro_name to $gds_file"
         }
     }
 }

--- a/openlane/scripts/magic/get_bbox.tcl
+++ b/openlane/scripts/magic/get_bbox.tcl
@@ -1,0 +1,11 @@
+gds read $::env(_GDS_IN)
+load $::env(_MACRO_NAME_IN)
+set properties [property]
+foreach property [property] {
+    if {[lindex $property 0] == "FIXED_BBOX"} {
+        puts "%OL_METRIC_I llx [lindex $property 1]"
+        puts "%OL_METRIC_I lly [lindex $property 2]"
+        puts "%OL_METRIC_I urx [lindex $property 3]"
+        puts "%OL_METRIC_I ury [lindex $property 4]"
+    }
+}

--- a/openlane/steps/magic.py
+++ b/openlane/steps/magic.py
@@ -129,7 +129,6 @@ class MagicStep(TclStep):
         env: Optional[Dict[str, Any]] = None,
         **kwargs,
     ) -> Dict[str, Any]:
-        print(cmd, kwargs)
         # https://github.com/RTimothyEdwards/magic/issues/218
         stdin = open(
             os.path.join(get_script_dir(), "magic", "wrapper.tcl"), encoding="utf8"
@@ -165,7 +164,9 @@ class MagicStep(TclStep):
             for line in open(log_to, encoding="utf8"):
                 for pattern in error_patterns:
                     if re.match(pattern, line):
-                        raise StepError(f"Error found in log {log_to}:\n\t{line}.")
+                        raise StepError(
+                            f"Error encountered during running Magic: In {log_to}:\n\t{line}."
+                        )
 
         return generated_metrics
 

--- a/openlane/steps/magic.py
+++ b/openlane/steps/magic.py
@@ -257,9 +257,7 @@ class StreamOut(MagicStep):
                     raise StepException(
                         "Multiple gds per macro not supported when MAGIC_MACRO_STD_CELL_SOURCE is set to 'macro'"
                     )
-                env_copy["_GDS_IN"] = [
-                    str(path) for path in self.config["MACROS"][macro].gds
-                ][0]
+                env_copy["_GDS_IN"] = macro_gdses[0]
                 env_copy["_MACRO_NAME_IN"] = macro
                 log_folder = os.path.join(self.step_dir, "get_bbox")
                 mkdirp(log_folder)
@@ -277,7 +275,7 @@ class StreamOut(MagicStep):
                     )
                 bbox = " ".join([str(value) for value in metrics_updates.values()])
                 macro_gds.append(macro)
-                macro_gds += [str(path) for path in self.config["MACROS"][macro].gds]
+                macro_gds += macro_gdses
                 macro_gds.append(bbox)
                 macro_gds += ","
 

--- a/openlane/steps/magic.py
+++ b/openlane/steps/magic.py
@@ -111,15 +111,15 @@ class MagicStep(TclStep):
             str(self.config["MAGICRC"]),
         ]
 
-    def run(
-        self, state_in: State, script: Optional[str] = None, **kwargs
-    ) -> Tuple[ViewsUpdate, MetricsUpdate]:
+    def run(self, state_in: State, **kwargs) -> Tuple[ViewsUpdate, MetricsUpdate]:
         # https://github.com/RTimothyEdwards/magic/issues/218
         kwargs, env = self.extract_env(kwargs)
         kwargs["stdin"] = open(
             os.path.join(get_script_dir(), "magic", "wrapper.tcl"), encoding="utf8"
         )
-        env["MAGIC_SCRIPT"] = script or self.get_script_path()
+        env["MAGIC_SCRIPT"] = kwargs.get("script") or self.get_script_path()
+        if kwargs.get("script"):
+            del kwargs["script"]
 
         env["MACRO_GDS_FILES"] = ""
         for gds in self.toolbox.get_macro_views(self.config, DesignFormat.GDS):

--- a/openlane/steps/tclstep.py
+++ b/openlane/steps/tclstep.py
@@ -19,7 +19,7 @@ from enum import Enum
 from decimal import Decimal
 from abc import abstractmethod
 from dataclasses import is_dataclass, asdict
-from typing import Any, ClassVar, List, Tuple
+from typing import Any, ClassVar, Iterable, List, Mapping, Tuple
 
 from .step import ViewsUpdate, MetricsUpdate, Step, StepException
 
@@ -30,6 +30,7 @@ from ..common import (
     GenericDictEncoder,
     get_script_dir,
     protected,
+    is_string,
 )
 
 
@@ -62,16 +63,16 @@ class TclStep(Step):
         """
         if is_dataclass(value):
             return json.dumps(asdict(value), cls=GenericDictEncoder)
-        elif isinstance(value, list) or isinstance(value, tuple):
-            result = []
-            for item in value:
-                result.append(TclStep.value_to_tcl(item))
-            return TclUtils.join(result)
-        elif isinstance(value, dict):
+        elif isinstance(value, Mapping):
             result = []
             for v_key, v_value in value.items():
                 result.append(TclStep.value_to_tcl(v_key))
                 result.append(TclStep.value_to_tcl(v_value))
+            return TclUtils.join(result)
+        elif isinstance(value, Iterable) and not is_string(value):
+            result = []
+            for item in value:
+                result.append(TclStep.value_to_tcl(item))
             return TclUtils.join(result)
         elif isinstance(value, Enum):
             return value.name


### PR DESCRIPTION
* `Magic.StreamOut`:
  * Fixed issue where black-boxed macros with non-north orientations are rotated around the incorrect point
  * Updated to throw errors when `MAGIC_MACRO_STD_CELL_SOURCE` is set to `macro` and:
    * Multiple GDS files are defined per macro
    * A macro's GDS file does not have a PR boundary 
* `MagicStep` no longer overrides `run`, but does override `run_subprocess`
* Changed `manual_macro_placement_test` design to have a macro with orientation `FN` as a test for this functionality


---
Resolves https://github.com/efabless/openlane2/issues/256
Depends on https://github.com/efabless/openlane2-ci-designs/pull/8