### PR TITLE
Nix: add system as input argument

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 {
+  system ? builtins.currentSystem,
   pkgs ? import ./nix/pkgs.nix {},
   gitignore-src ? import ./nix/gitignore.nix { inherit pkgs; },
   
@@ -58,7 +59,7 @@ with pkgs; with python3.pkgs; buildPythonPackage rec {
       eqy
       lighter
       synlig-sv
-    ] ++ (if builtins.currentSystem == "x86_64-linux" then [ys-ghdl] else []) ))
+    ] ++ (if system == "x86_64-linux" then [ys-ghdl] else []) ))
     opensta
     openroad
     klayout


### PR DESCRIPTION
* Added a new argument to `default.nix`, `system`, as `builtins.currentSystem` is not available when using nix flakes (where in documentation it is described as "non-hermetic and impure": see https://nixos.wiki/wiki/Flakes). This change allows passing the system as argument and thus restores compatibility with nix flakes.