### PR TITLE
Fix legacy calls to `Step.run(self, …)`

### DIFF
--- a/openlane/flows/flow.py
+++ b/openlane/flows/flow.py
@@ -653,9 +653,7 @@ class Flow(ABC):
         :param kwargs: Keyword arguments to `step.start`
         :returns: A ``Future`` encapsulating a State object, which can be used
             as an input to the next step (where the next step will wait for the
-            ``Future`` to be realized before calling :meth:`Step.run`).
-
-
+            ``Future`` to be realized before calling :meth:`Step.run`)
         """
 
         kwargs["toolbox"] = self.toolbox

--- a/openlane/steps/cvc_rv.py
+++ b/openlane/steps/cvc_rv.py
@@ -167,4 +167,4 @@ class ERC(Step):
             return {}, {}
         except CVCNoSupport as e:
             warn(f"Could not run CVC: {e}. Skipping…")
-            return Step.run(self, state_in, **kwargs)
+            return {}, {}

--- a/openlane/steps/openroad.py
+++ b/openlane/steps/openroad.py
@@ -1521,7 +1521,7 @@ class CTS(ResizerStep):
                 warn(
                     "No CLOCK_NET (or CLOCK_PORT) specified. CTS cannot be performed. Returning state unaltered…"
                 )
-                return Step.run(self, state_in, **kwargs)
+                return {}, {}
 
         views_updates, metrics_updates = super().run(
             state_in, corners_key="CTS_CORNERS", env=env, **kwargs


### PR DESCRIPTION
* `OpenROAD.CTS`, `CVCRV.ERC` (unused): Replaced legacy calls to `Fix legacy calls to `Step.run(self, …)`  causing crashes in some situations