### PR TITLE
`OpenROAD.ResizerTiming*`: Config Variable to Enable/Disable Cloning

### DIFF
--- a/openlane/scripts/openroad/rsz_timing_postcts.tcl
+++ b/openlane/scripts/openroad/rsz_timing_postcts.tcl
@@ -41,6 +41,9 @@ lappend arg_list -max_buffer_percent $::env(PL_RESIZER_HOLD_MAX_BUFFER_PCT)
 if { $::env(PL_RESIZER_ALLOW_SETUP_VIOS) == 1 } {
     lappend arg_list -allow_setup_violations
 }
+if { $::env(PL_RESIZER_GATE_CLONING) != 1 } {
+    lappend arg_list -skip_gate_cloning
+}
 repair_timing {*}$arg_list
 
 # Legalize

--- a/openlane/scripts/openroad/rsz_timing_postgrt.tcl
+++ b/openlane/scripts/openroad/rsz_timing_postgrt.tcl
@@ -41,6 +41,9 @@ lappend arg_list -max_buffer_percent $::env(GRT_RESIZER_HOLD_MAX_BUFFER_PCT)
 if { $::env(GRT_RESIZER_ALLOW_SETUP_VIOS) == 1 } {
     lappend arg_list -allow_setup_violations
 }
+if { $::env(GRT_RESIZER_GATE_CLONING) != 1 } {
+    lappend arg_list -skip_gate_cloning
+}
 repair_timing {*}$arg_list
 
 # Re-DPL and GRT

--- a/openlane/steps/openroad.py
+++ b/openlane/steps/openroad.py
@@ -1737,6 +1737,12 @@ class ResizerTimingPostCTS(ResizerStep):
             "Allows the creation of setup violations when fixing hold violations. Setup violations are less dangerous as they simply mean a chip may not run at its rated speed, however, chips with hold violations are essentially dead-on-arrival.",
             default=False,
         ),
+        Variable(
+            "PL_RESIZER_GATE_CLONING",
+            bool,
+            "Enables gate cloning when attempting to fix setup violations",
+            default=True,
+        ),
     ]
 
     def get_script_path(self):
@@ -1797,6 +1803,12 @@ class ResizerTimingPostGRT(ResizerStep):
             "Allows setup violations when fixing hold.",
             default=False,
             deprecated_names=["GLB_RESIZER_ALLOW_SETUP_VIOS"],
+        ),
+        Variable(
+            "GRT_RESIZER_GATE_CLONING",
+            bool,
+            "Enables gate cloning when attempting to fix setup violations",
+            default=True,
         ),
     ]
 


### PR DESCRIPTION
* `OpenROAD.ResizerTimingPostCTS`, `OpenROAD.ResizerTimingPostGRT`:
  * Added `PL_RESIZER_GATE_CLONING` and `GRT_RESIZER_GATE_CLONING` rspectively, which control `OpenROAD`'s ability when calling `repair_timing` (default: `true`)