### PR TITLE
Hotfix: `push` -> `manifest push`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -283,7 +283,7 @@ jobs:
             ghcr.io/${{ github.repository }}:$NEW_TAG-amd64\
             ghcr.io/${{ github.repository }}:$NEW_TAG-aarch64
 
-          docker push ghcr.io/${{ github.repository }}:$NEW_TAG
+          docker manifest push ghcr.io/${{ github.repository }}:$NEW_TAG
       - name: Set Up Python
         if: ${{ env.PUBLISH == '1' }}
         uses: actions/setup-python@v4


### PR DESCRIPTION
* Fixed the CI failing to push the final Docker manifest properly because of an omission.