### PR TITLE
Fix Docker image `PATH` issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,7 @@ jobs:
       - name: Download IPM designs
         id: download-ipm-design
         run: |
+          export GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
           ipm install-dep --ip-root $(realpath $IP_ROOT) --ipm-root ~/.ipm
           echo "dependencies_sha256sum=$(sha256sum $IP_ROOT/dependencies.json | cut -d ' ' -f1)" >> $GITHUB_OUTPUT
       - name: Cache IPM designs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,17 +57,17 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: true
+      - name: Cache IPM designs
+        uses: actions/cache@v3
+        with:
+          path: ~/.ipm
+          key: cache-ipm-designs-${{ steps.download-ipm-design.outputs.dependencies_sha256sum }}
       - name: Download IPM designs
         id: download-ipm-design
         run: |
           export GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
           ipm install-dep --ip-root $(realpath $IP_ROOT) --ipm-root ~/.ipm
           echo "dependencies_sha256sum=$(sha256sum $IP_ROOT/dependencies.json | cut -d ' ' -f1)" >> $GITHUB_OUTPUT
-      - name: Cache IPM designs
-        uses: actions/cache@v3
-        with:
-          path: ~/.ipm
-          key: cache-ipm-designs-${{ steps.download-ipm-design.outputs.dependencies_sha256sum }}
 
   lint:
     name: Lint

--- a/default.nix
+++ b/default.nix
@@ -108,12 +108,10 @@ with pkgs; with python3.pkgs; buildPythonPackage rec {
   doCheck = false;
   checkInputs = [ pytestCheckHook pyfakefs ];
 
-  computed_PATH = lib.makeBinPath (propagatedBuildInputs ++ buildInputs);
-  computed_PYTHONPATH = lib.makeSearchPath "lib/${python3.libPrefix}/site-packages" (propagatedBuildInputs ++ buildInputs);
-
-  # Make PATH/PYTHONPATH available to OpenLane subprocesses
+  computed_PATH = lib.makeBinPath (propagatedBuildInputs);
+  
+  # Make PATH available to OpenLane subprocesses
   makeWrapperArgs = [
     "--prefix PATH : ${computed_PATH}"
-    "--prefix PYTHONPATH : ${computed_PYTHONPATH}"
   ];
 }

--- a/openlane/steps/odb.py
+++ b/openlane/steps/odb.py
@@ -40,15 +40,18 @@ class OdbpyStep(Step):
     def run(self, state_in, **kwargs) -> Tuple[ViewsUpdate, MetricsUpdate]:
         kwargs, env = self.extract_env(kwargs)
 
-        out_paths = {}
+        automatic_outputs = set(self.outputs).intersection(
+            [DesignFormat.ODB, DesignFormat.DEF]
+        )
 
+        views_updates: ViewsUpdate = {}
         command = self.get_command()
-        for output in [DesignFormat.ODB, DesignFormat.DEF]:
+        for output in automatic_outputs:
             filename = f"{self.config['DESIGN_NAME']}.{output.value.extension}"
             file_path = os.path.join(self.step_dir, filename)
             command.append(f"--output-{output.value.id}")
             command.append(file_path)
-            out_paths[output] = Path(file_path)
+            views_updates[output] = Path(file_path)
 
         command += [
             str(state_in[DesignFormat.ODB]),
@@ -76,10 +79,6 @@ class OdbpyStep(Step):
                 elif value == "-Infinity":
                     or_metrics_out[key] = -inf
             metrics_updates.update(or_metrics_out)
-
-        views_updates: ViewsUpdate = {}
-        for output in [DesignFormat.ODB, DesignFormat.DEF]:
-            views_updates[output] = out_paths[output]
 
         return views_updates, metrics_updates
 

--- a/shell.nix
+++ b/shell.nix
@@ -24,7 +24,9 @@ with pkgs; let
       pytest
       pillow
       mdformat
-    ] ++ openlane-plugins ));
+    ] ++ openlane-plugins )
+  ); in let
+  openlane-env-sitepackages = "${openlane-env}/${openlane-env.sitePackages}";
   pluginIncludedTools = lib.lists.flatten (map (n: n.includedTools) openlane-plugins);
 in mkShell {
   name = "openlane-shell";
@@ -45,4 +47,6 @@ in mkShell {
     jupyter
     graphviz
   ] ++ openlane.includedTools ++ pluginIncludedTools;
+  
+  PYTHONPATH = "${openlane-env-sitepackages}"; # Allows venvs to work properly
 }

--- a/shell.nix
+++ b/shell.nix
@@ -18,20 +18,20 @@
 }:
 
 with pkgs; let
-  pluginIncludedTools = lib.lists.flatten (map (n: n.includedTools) openlane-plugins)
-  
-; in mkShell {
-  name = "openlane-shell";
-
-  propagatedBuildInputs = [
-    (python3.withPackages(pp: with pp; [
+  openlane-env = (python3.withPackages(pp: with pp; [
       openlane
       pyfakefs
       pytest
       pillow
       mdformat
-    ] ++ openlane-plugins ))
+    ] ++ openlane-plugins ));
+  pluginIncludedTools = lib.lists.flatten (map (n: n.includedTools) openlane-plugins);
+in mkShell {
+  name = "openlane-shell";
 
+  propagatedBuildInputs = [
+    openlane-env
+    
     # Conveniences
     git
     zsh
@@ -45,6 +45,4 @@ with pkgs; let
     jupyter
     graphviz
   ] ++ openlane.includedTools ++ pluginIncludedTools;
-
-  PYTHONPATH = openlane.computed_PYTHONPATH;
 }


### PR DESCRIPTION
* Fixed an issue where Docker images did not properly have dependencies of dependencies set in `PYTHONPATH`.
* Fixed Docker images not having `TMPDIR` set by default.
* Removed `PYTHONPATH` from `default.nix` - OpenLane now passes its `site-packages` to subprocesses (less jank but still jank)

## CI

* Fixed IPM install command being rate-limited
* Fixed IPM caching order (the cache action should come first)

---
Resolves #307 

Depends on https://github.com/efabless/openlane2-step-unit-tests/pull/17