### PR TITLE
Timing Violation Checkers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,4 +36,4 @@ slpp_all/
 htmlcov/
 prof/
 sandbox/
-designs
+/designs

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ slpp_all/
 htmlcov/
 prof/
 sandbox/
+designs

--- a/openlane/flows/classic.py
+++ b/openlane/flows/classic.py
@@ -227,6 +227,24 @@ _common_config_vars = [
         default=True,
         deprecated_names=["FP_PDN_CHECK_NODES"],
     ),
+    Variable(
+        "QUIT_ON_SETUP_VIOLATIONS",
+        bool,
+        "Check for setup violations in selected corners",
+        default=True,
+    ),
+    Variable(
+        "QUIT_ON_HOLD_VIOLATIONS",
+        bool,
+        "Check for setup violations in selected corners",
+        default=True,
+    ),
+    Variable(
+        "QUIT_ON_TIMING_VIOLATIONS",
+        bool,
+        "Check for timing violations in selected corners",
+        default=True,
+    ),
 ]
 
 _common_gating_config_vars = {
@@ -270,6 +288,11 @@ _common_gating_config_vars = {
     "Checker.LVS": ["RUN_LVS", "QUIT_ON_LVS_ERROR"],
     "Checker.KLayoutDRC": ["RUN_KLAYOUT_DRC", "QUIT_ON_KLAYOUT_DRC"],
     "Checker.PowerGridViolations": ["QUIT_ON_PDN_VIOLATIONS"],
+    "Checker.SetupViolations": [
+        "QUIT_ON_TIMING_VIOLATIONS",
+        "QUIT_ON_SETUP_VIOLATIONS",
+    ],
+    "Checker.HoldViolations": ["QUIT_ON_TIMING_VIOLATIONS", "QUIT_ON_HOLD_VIOLATIONS"],
 }
 
 
@@ -347,7 +370,8 @@ class Classic(SequentialFlow):
         Netgen.LVS,
         Checker.LVS,
         Yosys.EQY,
-        Checker.TimingViolations,
+        Checker.SetupViolations,
+        Checker.HoldViolations,
     ]
 
     config_vars = _common_config_vars + [

--- a/openlane/flows/classic.py
+++ b/openlane/flows/classic.py
@@ -347,6 +347,7 @@ class Classic(SequentialFlow):
         Netgen.LVS,
         Checker.LVS,
         Yosys.EQY,
+        Checker.TimingViolations,
     ]
 
     config_vars = _common_config_vars + [

--- a/openlane/steps/checker.py
+++ b/openlane/steps/checker.py
@@ -352,6 +352,7 @@ class TimingViolations(MetricChecker):
         return {}, {}
 
 
+@Step.factory.register()
 class SetupViolations(TimingViolations):
     id = "Checker.SetupViolations"
     name = "Setup Timing Violations Checker"
@@ -360,6 +361,7 @@ class SetupViolations(TimingViolations):
     metric_name = "timing__setup_vio__count"
 
 
+@Step.factory.register()
 class HoldViolations(TimingViolations):
     id = "Checker.HoldViolations"
     name = "Hold Timing Violations Checker"

--- a/openlane/steps/checker.py
+++ b/openlane/steps/checker.py
@@ -251,18 +251,16 @@ class KLayoutDRC(MetricChecker):
     metric_description = "KLayout DRC errors"
 
 
-@Step.factory.register()
 class TimingViolations(MetricChecker):
-    id = "Checker.TimingViolations"
     name = "Timing Violations Checker"
     long_name = "Timing Violations Checker"
-    violation_type = "Timing"
+    violation_type: str = NotImplemented
 
     config_vars = [
         Variable(
             "TIMING_VIOLATIONS_CORNERS",
             List[str],
-            "A list of fully-qualifiedd IPVT corners to use during checking for timing violations.",
+            "A list of wildcards matching IPVT corners to use during checking for timing violations.",
             default=["*tt*"],
         ),
     ]


### PR DESCRIPTION
* Added `Checker.SetupViolations `, `Checker.HoldViolations` to check setup/hold timing violations
  * Add config variable `TIMING_VIOLATIONS_CORNERS`, which is a list of wildcards to match corners those steps will flag an error on.
* `Classic`:
  * Added `Checker.SetupViolations`, `Checker.HoldViolations` to the end of the flow
    * Both gated by `QUIT_ON_TIMING_VIOLATIONS`
    * Each gated by `QUIT_ON_SETUP_VIOLATIONS`, `QUIT_ON_HOLD_VIOLATIONS` respectively

## Misc
* Added `/designs` to `.gitignore`

## Testing
* Added units test for `Checker.StepViolations` and `Checker.HoldViolations`

---

depends on: https://github.com/efabless/openlane2-step-unit-tests/pull/19
Fixes https://github.com/efabless/openlane2/issues/286