### PR TITLE
Allow cells matching `TRISTATE_CELLS` in `SYNTH_CHECKS_ALLOW_TRISTATE`

### DIFF
--- a/openlane/config/flow.py
+++ b/openlane/config/flow.py
@@ -14,10 +14,17 @@
 import os
 
 from decimal import Decimal
-from typing import List, Optional, Dict, Union, Tuple
+from typing import List, Optional, Dict, Sequence, Union, Tuple
 
 from .variable import Variable, Macro
 from ..common import Path, get_script_dir
+
+
+def _prefix_to_wildcard(prefixes_raw: Union[str, Sequence[str]]):
+    prefixes = prefixes_raw
+    if isinstance(prefixes, str):
+        prefixes = prefixes.split()
+    return [f"{prefix}*" for prefix in prefixes]
 
 
 pdk_variables = [
@@ -78,9 +85,10 @@ pdk_variables = [
         pdk=True,
     ),
     Variable(
-        "GPIO_PADS_PREFIX",
+        "GPIO_PAD_CELLS",
         Optional[List[str]],
         "A list of pad cell name prefixes.",
+        deprecated_names=[("GPIO_PADS_PREFIX", _prefix_to_wildcard)],
         pdk=True,
     ),
     Variable(
@@ -171,9 +179,10 @@ scl_variables = [
         pdk=True,
     ),
     Variable(
-        "TRISTATE_CELL_PREFIX",
-        Optional[str],
-        "A common prefix of tristate cells.",
+        "TRISTATE_CELLS",
+        Optional[List[str]],
+        "A list of cell names or wildcards of tri-state buffers.",
+        deprecated_names=[("TRISTATE_CELL_PREFIX", _prefix_to_wildcard)],
         pdk=True,
     ),
     Variable(

--- a/openlane/config/flow.py
+++ b/openlane/config/flow.py
@@ -171,6 +171,12 @@ scl_variables = [
         pdk=True,
     ),
     Variable(
+        "TRISTATE_CELL_PREFIX",
+        str,
+        "A common prefix of tristate cells.",
+        pdk=True,
+    ),
+    Variable(
         "FILL_CELL",
         List[str],
         "A list of cell names or wildcards of fill cells to be used in fill insertion.",

--- a/openlane/config/flow.py
+++ b/openlane/config/flow.py
@@ -172,7 +172,7 @@ scl_variables = [
     ),
     Variable(
         "TRISTATE_CELL_PREFIX",
-        str,
+        Optional[str],
         "A common prefix of tristate cells.",
         pdk=True,
     ),

--- a/openlane/steps/yosys.py
+++ b/openlane/steps/yosys.py
@@ -15,8 +15,9 @@ import os
 import re
 import io
 import json
-import subprocess
+import fnmatch
 import textwrap
+import subprocess
 from decimal import Decimal
 from abc import abstractmethod
 from typing import List, Literal, Optional, Tuple
@@ -31,33 +32,52 @@ from ..common import Path, get_script_dir, Toolbox, TclUtils
 
 starts_with_whitespace = re.compile(r"^\s+.+$")
 
+yosys_cell_rx = r"cell\s+\S+\s+\((\S+)\)"
+
+
+def _check_any_tristate(
+    cells: List[str],
+    tristate_patterns: List[str],
+):
+    for cell in cells:
+        for tristate_pattern in tristate_patterns:
+            if fnmatch.fnmatch(cell, tristate_pattern):
+                return True
+
+    return False
+
 
 def _parse_yosys_check(
     report: io.TextIOBase,
-    tristate_cell_prefix: Optional[str],
+    tristate_patterns: Optional[List[str]] = None,
     tristate_okay: bool = False,
 ) -> int:
     verbose("Parsing synthesis checks…")
     errors_encountered: int = 0
+    last_warning = None
     current_warning = None
+
+    tristate_patterns = tristate_patterns or []
 
     for line in report:
         if line.startswith("Warning:") or line.startswith("Found and reported"):
-            if current_warning is not None:
-                if tristate_okay and (
-                    ("tribuf" in current_warning)
-                    or (
-                        tristate_cell_prefix is not None
-                        and tristate_cell_prefix in current_warning
-                    )
-                ):
-                    debug("Ignoring tristate-related error:")
-                    debug(current_warning)
-                else:
-                    debug("Encountered check error:")
-                    debug(current_warning)
-                    errors_encountered += 1
+            last_warning = current_warning
             current_warning = line
+            if last_warning is None:
+                continue
+
+            cells = re.findall(yosys_cell_rx, last_warning)
+
+            if tristate_okay and (
+                ("tribuf" in last_warning)
+                or _check_any_tristate(cells, tristate_patterns)
+            ):
+                debug("Ignoring tristate-related error:")
+                debug(last_warning)
+            else:
+                debug("Encountered check error:")
+                debug(last_warning)
+                errors_encountered += 1
         elif (
             starts_with_whitespace.match(line) is not None
             and current_warning is not None
@@ -391,7 +411,7 @@ class SynthesisCommon(YosysStep):
         if os.path.exists(check_error_count_file):
             metric_updates["synthesis__check_error__count"] = _parse_yosys_check(
                 open(check_error_count_file),
-                self.config["TRISTATE_CELL_PREFIX"],
+                self.config["TRISTATE_CELLS"],
                 self.config["SYNTH_CHECKS_ALLOW_TRISTATE"],
             )
 


### PR DESCRIPTION
* Renamed GPIO_PADS_PREFIX to GPIO_PAD_CELLS, accepting with translation behavior
* Created `TRISTATE_CELLS` for parity with OpenLane, accepting (multiple) wildcards and `TRISTATE_CELL_PREFIX` with translation behavior

## Testing
* Added test for both hand-instantiating tri-state buffers AND high-impedance derived tri-state buffers

---

Fixes #285 
Depends on https://github.com/efabless/openlane2-step-unit-tests/pull/20