### PR TITLE
Port features from OL1

### DIFF
--- a/openlane/scripts/openroad/common/set_global_connections.tcl
+++ b/openlane/scripts/openroad/common/set_global_connections.tcl
@@ -36,6 +36,7 @@ proc set_global_connections {} {
     if { $::env(PDN_CONNECT_MACROS_TO_GRID) == 1 &&
         [info exists ::env(PDN_MACRO_CONNECTIONS)]} {
         foreach pdn_hook $::env(PDN_MACRO_CONNECTIONS) {
+            set pdn_hook [regexp -all -inline {\S+} $pdn_hook]
             set instance_name [lindex $pdn_hook 0]
             set power_net [lindex $pdn_hook 1]
             set ground_net [lindex $pdn_hook 2]
@@ -47,9 +48,11 @@ proc set_global_connections {} {
                 exit -1
             }
 
+            set matched 0
             foreach cell [[ord::get_db_block] getInsts] {
                 if { [regexp "\^$instance_name" [$cell getName]] } {
                     set matched 1
+                    puts "$instance_name matched with [$cell getName]"
                 }
             }
             if { $matched != 1 } {

--- a/openlane/scripts/openroad/common/set_global_connections.tcl
+++ b/openlane/scripts/openroad/common/set_global_connections.tcl
@@ -47,6 +47,16 @@ proc set_global_connections {} {
                 exit -1
             }
 
+            foreach cell [[ord::get_db_block] getInsts] {
+                if { [regexp "\^$instance_name" [$cell getName]] } {
+                    set matched 1
+                }
+            }
+            if { $matched != 1 } {
+                puts "No regex match found for $instance_name defined in PDN_MACRO_CONNECTIONS"
+                exit 1
+            }
+
             add_global_connection \
                 -net $power_net \
                 -inst_pattern $instance_name \

--- a/openlane/scripts/openroad/gpl.tcl
+++ b/openlane/scripts/openroad/gpl.tcl
@@ -63,8 +63,11 @@ set cell_pad_side [expr $::env(GPL_CELL_PADDING) / 2]
 
 lappend arg_list -pad_right $cell_pad_side
 lappend arg_list -pad_left $cell_pad_side
+lappend arg_list -init_wirelength_coef $::env(PL_WIRELENGTH_COEF)
 
+puts "{*}$arg_list"
 global_placement {*}$arg_list
+
 
 source $::env(SCRIPTS_DIR)/openroad/common/set_rc.tcl
 estimate_parasitics -placement

--- a/openlane/steps/openroad.py
+++ b/openlane/steps/openroad.py
@@ -178,7 +178,7 @@ class OpenROADStep(TclStep):
         Variable(
             "PDN_MACRO_CONNECTIONS",
             Optional[List[str]],
-            "Specifies explicit power connections of internal macros to the top level power grid, in the format: macro instance names, power domain vdd and ground net names, and macro vdd and ground pin names `<instance_name> <vdd_net> <gnd_net> <vdd_pin> <gnd_pin>`.",
+            "Specifies explicit power connections of internal macros to the top level power grid, in the format: regex matching macro instance names, power domain vdd and ground net names, and macro vdd and ground pin names `<instance_name_rx> <vdd_net> <gnd_net> <vdd_pin> <gnd_pin>`.",
             deprecated_names=[("FP_PDN_MACRO_HOOKS", pdn_macro_migrator)],
         ),
         Variable(
@@ -926,11 +926,12 @@ class GlobalPlacement(OpenROADStep):
                 default=True,
             ),
             Variable(
-                "PL_WIRELENGTH_COEF",
+                "PL_WIRE_LENGTH_COEF",
                 Decimal,
                 "Global placement initial wirelength coefficient."
-                + "Decreasing the variable will modify the initial placement of the standard cells to reduce the wirelengths",
+                + " Decreasing the variable will modify the initial placement of the standard cells to reduce the wirelengths",
                 default=0.25,
+                deprecated_names=["PL_WIRELENGTH_COEF"],
             ),
             Variable(
                 "FP_CORE_UTIL",

--- a/openlane/steps/openroad.py
+++ b/openlane/steps/openroad.py
@@ -926,6 +926,13 @@ class GlobalPlacement(OpenROADStep):
                 default=True,
             ),
             Variable(
+                "PL_WIRELENGTH_COEF",
+                Decimal,
+                "Global placement initial wirelength coefficient."
+                + "Decreasing the variable will modify the initial placement of the standard cells to reduce the wirelengths",
+                default=0.25,
+            ),
+            Variable(
                 "FP_CORE_UTIL",
                 Decimal,
                 "The core utilization percentage.",


### PR DESCRIPTION
* `OpenROAD.*`
  * Added regex matching check for patterns inside `PDN_MACRO_CONNECTIONS`
    * Updated `PDN_MACRO_CONNECTIONS` documentation to highlight the fact the instance name is actually a regex
    * Fix a bug in `PDN_MACRO_CONNECTION` related to double escaping of special characters. 
* `OpenROAD.GlobalPlacement`
  * Added new variable `PL_WIRE_LENGTH_COEF` passed as `-init_wirelength_coef` to OpenROAD