### PR TITLE
Clean up universal flow variables

### DIFF
--- a/openlane/config/flow.py
+++ b/openlane/config/flow.py
@@ -344,65 +344,25 @@ scl_variables = [
         "Defines a buffer port to be used by yosys during synthesis: in the format `{cell}/{input_port}/{output_port}`",
         pdk=True,
     ),
-    # Clock Tree Synthesis
     Variable(
-        "CTS_ROOT_BUFFER",
-        str,
-        "Defines the cell inserted at the root of the clock tree. Used in CTS.",
-        pdk=True,
-    ),
-    Variable(
-        "CTS_CLK_BUFFERS",
-        List[str],
-        "Defines the list of clock buffers to be used in CTS.",
-        deprecated_names=["CTS_CLK_BUFFER_LIST"],
-        pdk=True,
-    ),
-    Variable(
-        "CTS_MAX_CAP",
-        Decimal,
-        "Defines the maximum capacitance, used in CTS.",
-        units="pF",
-        pdk=True,
-    ),
-    # Floorplanning
-    Variable(
-        "FP_WELLTAP_CELL",
+        "WELLTAP_CELL",
         str,
         "Defines the cell used for tap insertion.",
         pdk=True,
+        deprecated_names=["FP_WELLTAP_CELL"],
     ),
     Variable(
-        "FP_ENDCAP_CELL",
+        "ENDCAP_CELL",
         str,
         "Defines so-called 'end-cap' cells- decap cells placed at either sides of a design.",
         pdk=True,
-    ),
-    Variable(
-        "IGNORE_DISCONNECTED_MODULES",
-        Optional[List[str]],
-        "Modules (or cells) to ignore when checking for disconnected pins.",
-        pdk=True,
+        deprecated_names=["FP_ENDCAP_CELL"],
     ),
     # Placement
     Variable(
         "PLACE_SITE",
         str,
         "Defines the primary placement site in placement as specified in the technology LEF files, to generate the placement grid.",
-        pdk=True,
-    ),
-    Variable(
-        "GPL_CELL_PADDING",
-        Decimal,
-        "Cell padding value (in sites) for global placement. The number will be integer divided by 2 and placed on both sides.",
-        units="sites",
-        pdk=True,
-    ),
-    Variable(
-        "DPL_CELL_PADDING",
-        Decimal,
-        "Cell padding value (in sites) for detailed placement. The number will be integer divided by 2 and placed on both sides. Should be <= global placement.",
-        units="sites",
         pdk=True,
     ),
     Variable(
@@ -416,13 +376,6 @@ scl_variables = [
         "DIODE_CELL",
         Optional[str],
         "Defines a diode cell used to fix antenna violations, in the format {name}/{port}.",
-        pdk=True,
-    ),
-    # Routing
-    Variable(
-        "GRT_LAYER_ADJUSTMENTS",
-        List[Decimal],
-        "Layer-specific reductions in the routing capacity of the edges between the cells in the global routing graph, delimited by commas. Values range from 0 through 1.",
         pdk=True,
     ),
 ]
@@ -513,51 +466,6 @@ option_variables = [
         "EXTRA_GDS_FILES",
         Optional[List[Path]],
         "Specifies GDS files of pre-hardened macros used in the current design, used during tape-out.",
-    ),
-    # Unimplemented - To be moved to steps
-    Variable(
-        "FP_CONTEXT_DEF",
-        Optional[Path],
-        "Points to the parent DEF file that includes this macro/design and uses this DEF file to determine the best locations for the pins. It must be used with `FP_CONTEXT_LEF`, otherwise it's considered non-existing. If not set, then the IO pins will be placed based on one of the other methods depending on the rest of the configurations.",
-    ),
-    Variable(
-        "FP_CONTEXT_LEF",
-        Optional[Path],
-        "Points to the parent LEF file that includes this macro/design and uses this LEF file to determine the best locations for the pins. It must be used with `FP_CONTEXT_DEF`, otherwise it's considered non-existing. If not set, then the IO pins will be placed based on one of the other methods depending on the rest of the configurations.",
-    ),
-    Variable(
-        "FP_PADFRAME_CFG",
-        Optional[str],
-        "A configuration file passed to `padringer`, a padframe generator.",
-    ),
-    Variable(
-        "GRT_OBS",
-        Optional[List[str]],
-        'Specifies custom obstruction to be added prior to global routing. List of layer and coordinates: `layer llx lly urx ury`, where `ll` and `ur` stand for "lower left" and "upper right" respectively. (Example: `li1 0 100 1000 300, met5 0 0 1000 500`).',
-    ),
-    Variable(
-        "LVS_INSERT_POWER_PINS",
-        bool,
-        "Enables power pin insertion before running LVS.",
-        default=True,
-    ),
-    Variable(
-        "RUN_CVC",
-        bool,
-        "Runs the Circuit Validity Checker on the output spice, which is a voltage-aware ERC checker for CDL netlists. Will not run unless supported by the current PDK.",
-        default=True,
-    ),
-    Variable(
-        "LEC_ENABLE",
-        bool,
-        "Enables logic verification using yosys, for comparing each netlist at each stage of the flow with the previous netlist and verifying that they are logically equivalent. Warning: this will increase the runtime significantly.",
-        default=False,
-    ),
-    Variable(
-        "CHECK_ASSIGN_STATEMENTS",
-        bool,
-        "Checks for assign statement in the generated gate level netlist and aborts if any were found.",
-        default=False,
     ),
     Variable(
         "FALLBACK_SDC_FILE",

--- a/openlane/config/removals.py
+++ b/openlane/config/removals.py
@@ -36,7 +36,7 @@ removed_variables: Dict[str, str] = {
     "MAGIC_GDS_ALLOW_ABSTRACT": "Bad practice. If an abstract view is needed, a GDS file can be generated from the abstract LEF file.",
     "PLACE_SITE_HEIGHT": "Now automatically extracted from PLACE_SITE.",
     "PLACE_SITE_WIDTH": "Now automatically extracted from PLACE_SITE.",
-    "LEC_ENABLE": "Complex, unscalable, and largely reundant.",
+    "LEC_ENABLE": "Buggy/doesn't scale properly.",
     "LVS_INSERT_POWER_PINS": "No longer necessary.",
     "RUN_CVC": "Upstream no longer supports CVC for use within OpenLane.",
     "FP_PADFRAME_CFG": "To be implemented.",

--- a/openlane/config/removals.py
+++ b/openlane/config/removals.py
@@ -36,4 +36,10 @@ removed_variables: Dict[str, str] = {
     "MAGIC_GDS_ALLOW_ABSTRACT": "Bad practice. If an abstract view is needed, a GDS file can be generated from the abstract LEF file.",
     "PLACE_SITE_HEIGHT": "Now automatically extracted from PLACE_SITE.",
     "PLACE_SITE_WIDTH": "Now automatically extracted from PLACE_SITE.",
+    "LEC_ENABLE": "Complex, unscalable, and largely reundant.",
+    "LVS_INSERT_POWER_PINS": "No longer necessary.",
+    "RUN_CVC": "Upstream no longer supports CVC for use within OpenLane.",
+    "FP_PADFRAME_CFG": "To be implemented.",
+    "FP_CONTEXT_DEF": "To be implemented.",
+    "FP_CONTEXT_LEF": "To be implemented.",
 }

--- a/openlane/scripts/openroad/common/io.tcl
+++ b/openlane/scripts/openroad/common/io.tcl
@@ -265,7 +265,7 @@ proc write_views {args} {
     }
 
     if { [info exists ::env(SAVE_POWERED_NETLIST_NO_PHYSICAL_CELLS)] } {
-        set exclude_cells "[join [lindex [split $::env(DIODE_CELL) "/"] 0]] [join $::env(FILL_CELL)] [join $::env(DECAP_CELL)] [join $::env(FP_WELLTAP_CELL)] [join $::env(FP_ENDCAP_CELL)]"
+        set exclude_cells "[join [lindex [split $::env(DIODE_CELL) "/"] 0]] [join $::env(FILL_CELL)] [join $::env(DECAP_CELL)] [join $::env(WELLTAP_CELL)] [join $::env(ENDCAP_CELL)]"
         puts "Writing nofilldiode powered netlist to '$::env(SAVE_POWERED_NETLIST_NO_PHYSICAL_CELLS)'…"
         puts "Excluding $exclude_cells"
         write_verilog -include_pwr_gnd \

--- a/openlane/scripts/openroad/common/io.tcl
+++ b/openlane/scripts/openroad/common/io.tcl
@@ -256,7 +256,7 @@ proc write_views {args} {
     }
 
     if { [info exists ::env(SAVE_POWERED_NETLIST_SDF_FRIENDLY)] } {
-        set exclude_cells "[join $::env(FILL_CELL)] [join $::env(DECAP_CELL)] [join $::env(FP_WELLTAP_CELL)] [join $::env(FP_ENDCAP_CELL)]"
+        set exclude_cells "[join $::env(FILL_CELL)] [join $::env(DECAP_CELL)] [join $::env(WELLTAP_CELL)] [join $::env(ENDCAP_CELL)]"
         puts "Writing nofill powered netlist to '$::env(SAVE_POWERED_NETLIST_SDF_FRIENDLY)'…"
         puts "Excluding $exclude_cells"
         write_verilog -include_pwr_gnd \

--- a/openlane/scripts/openroad/cut_rows.tcl
+++ b/openlane/scripts/openroad/cut_rows.tcl
@@ -15,7 +15,7 @@ source $::env(SCRIPTS_DIR)/openroad/common/io.tcl
 read_current_odb
 
 cut_rows\
-    -endcap_master $::env(FP_ENDCAP_CELL)\
+    -endcap_master $::env(ENDCAP_CELL)\
     -halo_width_x $::env(FP_MACRO_HORIZONTAL_HALO)\
     -halo_width_y $::env(FP_MACRO_VERTICAL_HALO)
 

--- a/openlane/scripts/openroad/tapcell.tcl
+++ b/openlane/scripts/openroad/tapcell.tcl
@@ -16,8 +16,8 @@ read_current_odb
 
 tapcell\
     -distance $::env(FP_TAPCELL_DIST)\
-    -tapcell_master "$::env(FP_WELLTAP_CELL)"\
-    -endcap_master "$::env(FP_ENDCAP_CELL)"\
+    -tapcell_master "$::env(WELLTAP_CELL)"\
+    -endcap_master "$::env(ENDCAP_CELL)"\
     -halo_width_x $::env(FP_MACRO_HORIZONTAL_HALO)\
     -halo_width_y $::env(FP_MACRO_VERTICAL_HALO)
 

--- a/openlane/steps/common_variables.py
+++ b/openlane/steps/common_variables.py
@@ -257,6 +257,12 @@ routing_layer_variables = [
         "Sets the number of GCells added to the blockages boundaries from macros. A GCell is typically defined in terms of Mx routing tracks. The default GCell size is 15 M3 pitches.",
         default=0,
     ),
+    Variable(
+        "GRT_LAYER_ADJUSTMENTS",
+        List[Decimal],
+        "Layer-specific reductions in the routing capacity of the edges between the cells in the global routing graph, delimited by commas. Values range from 0 through 1.",
+        pdk=True,
+    ),
 ]
 
 
@@ -280,6 +286,13 @@ dpl_variables = [
         "Specifies how far an instance can be moved along the Y-axis when finding a site where it can be placed during detailed placement.",
         default=100,
         units="µm",
+    ),
+    Variable(
+        "DPL_CELL_PADDING",
+        Decimal,
+        "Cell padding value (in sites) for detailed placement. The number will be integer divided by 2 and placed on both sides. Should be <= global placement.",
+        units="sites",
+        pdk=True,
     ),
 ]
 

--- a/openlane/steps/odb.py
+++ b/openlane/steps/odb.py
@@ -278,6 +278,16 @@ class ReportDisconnectedPins(OdbpyStep):
     id = "Odb.ReportDisconnectedPins"
     name = "Report Disconnected Pins"
 
+    config_vars = OdbpyStep.config_vars + [
+        # Why is this a PDK variable again
+        Variable(
+            "IGNORE_DISCONNECTED_MODULES",
+            Optional[List[str]],
+            "Modules (or cells) to ignore when checking for disconnected pins.",
+            pdk=True,
+        ),
+    ]
+
     def get_script_path(self):
         return os.path.join(get_script_dir(), "odbpy", "disconnected_pins.py")
 
@@ -302,6 +312,7 @@ class AddRoutingObstructions(OdbpyStep):
             + " Format of each obstruction item is: layer llx lly urx ury.",
             units="µm",
             default=None,
+            deprecated_names=["GRT_OBS"],
         ),
     ]
 

--- a/openlane/steps/odb.py
+++ b/openlane/steps/odb.py
@@ -279,7 +279,6 @@ class ReportDisconnectedPins(OdbpyStep):
     name = "Report Disconnected Pins"
 
     config_vars = OdbpyStep.config_vars + [
-        # Why is this a PDK variable again
         Variable(
             "IGNORE_DISCONNECTED_MODULES",
             Optional[List[str]],

--- a/openlane/steps/odb.py
+++ b/openlane/steps/odb.py
@@ -466,6 +466,13 @@ class PortDiodePlacement(OdbpyStep):
             "Always insert diodes on ports with the specified polarities.",
             default="none",
         ),
+        Variable(
+            "GPL_CELL_PADDING",
+            Decimal,
+            "Cell padding value (in sites) for global placement. Used by this step only to emit a warning if it's 0.",
+            units="sites",
+            pdk=True,
+        ),
     ]
 
     def get_script_path(self):
@@ -560,6 +567,13 @@ class FuzzyDiodePlacement(OdbpyStep):
             Decimal,
             "A manhattan distance above which a diode is recommended to be inserted by the heuristic inserter. If not specified, the heuristic algorithm.",
             units="µm",
+            pdk=True,
+        ),
+        Variable(
+            "GPL_CELL_PADDING",
+            Decimal,
+            "Cell padding value (in sites) for global placement. Used by this step only to emit a warning if it's 0.",
+            units="sites",
             pdk=True,
         ),
     ]

--- a/openlane/steps/openroad.py
+++ b/openlane/steps/openroad.py
@@ -940,6 +940,13 @@ class GlobalPlacement(OpenROADStep):
                 default=50,
                 units="%",
             ),
+            Variable(
+                "GPL_CELL_PADDING",
+                Decimal,
+                "Cell padding value (in sites) for global placement. The number will be integer divided by 2 and placed on both sides.",
+                units="sites",
+                pdk=True,
+            ),
         ]
     )
 
@@ -1700,6 +1707,26 @@ class CTS(ResizerStep):
                 "CTS_CORNERS",
                 Optional[List[str]],
                 "A list of fully-qualified IPVT corners to use during clock tree synthesis. If unspecified, the value for `STA_CORNERS` from the PDK will be used.",
+            ),
+            Variable(
+                "CTS_ROOT_BUFFER",
+                str,
+                "Defines the cell inserted at the root of the clock tree. Used in CTS.",
+                pdk=True,
+            ),
+            Variable(
+                "CTS_CLK_BUFFERS",
+                List[str],
+                "Defines the list of clock buffers to be used in CTS.",
+                deprecated_names=["CTS_CLK_BUFFER_LIST"],
+                pdk=True,
+            ),
+            Variable(
+                "CTS_MAX_CAP",
+                Decimal,
+                "Defines the maximum capacitance, used in CTS.",
+                units="pF",
+                pdk=True,
             ),
         ]
     )


### PR DESCRIPTION
* Universal Flow Variables
  * Renamed `FP_WELLTAP_CELL` to `WELLTAP_CELL` with translation behavior
  * Renamed `FP_ENDCAP_CELL` to `ENDCAP_CELL` with translation behavior
  * **API Breaks**
    * `CTS_ROOT_BUFFER`, `CTS_CLK_BUFFERS` and `CTS_MAX_CAP` all moved to `OpenROAD.CTS`
    * `IGNORE_DISCONNECTED_MODULES` moved to `Odb.ReportDisconnectedPins`
    * `GPL_CELL_PADDING` moved to `OpenROAD.GlobalPlacement`
    * `DPL_CELL_PADDING` moved to steps that have the rest of the `dpl` variables
    * `GRT_LAYER_ADJUSTMENTS` moved to steps that have the rest of the routing layer variables
    * Moved `GRT_OBS` to `Odb.AddRoutingObstructions` as a deprecated name for `ROUTING_OBSTRUCTIONS`
    * Removed `FP_CONTEXT_DEF`, `FP_CONTEXT_LEF`, and `FP_PADFRAME_CFG`: To be implemented
    * Removed `LVS_INSERT_POWER_PINS`, `RUN_CVC`, `LEC_ENABLE`, `CHECK_ASSIGN_STATEMENTS`

---

Resolves #362 