### PR TITLE
Handle non-UTF-8 outputs by subprocesses

### DIFF
--- a/openlane/steps/step.py
+++ b/openlane/steps/step.py
@@ -1042,7 +1042,6 @@ class Step(ABC):
                     f"Environment variable for key '{key}' is of invalid type {type(value)}: {value}"
                 )
 
-        print(cmd_str, kwargs)
         process = psutil.Popen(
             cmd_str,
             encoding="utf8",

--- a/openlane/steps/step.py
+++ b/openlane/steps/step.py
@@ -194,15 +194,19 @@ class ProcessStatsThread(Thread):
         return {
             "time": {k: format_elapsed_time(self.time[k]) for k in self.time},
             "peak_resources": {
-                k: self.peak_resources[k]
-                if "memory" not in k
-                else format_size(int(self.peak_resources[k]))
+                k: (
+                    self.peak_resources[k]
+                    if "memory" not in k
+                    else format_size(int(self.peak_resources[k]))
+                )
                 for k in self.peak_resources
             },
             "avg_resources": {
-                k: self.avg_resources[k]
-                if "memory" not in k
-                else format_size(int(self.avg_resources[k]))
+                k: (
+                    self.avg_resources[k]
+                    if "memory" not in k
+                    else format_size(int(self.avg_resources[k]))
+                )
                 for k in self.avg_resources
             },
         }
@@ -1038,6 +1042,7 @@ class Step(ABC):
                     f"Environment variable for key '{key}' is of invalid type {type(value)}: {value}"
                 )
 
+        print(cmd_str, kwargs)
         process = psutil.Popen(
             cmd_str,
             encoding="utf8",
@@ -1050,33 +1055,38 @@ class Step(ABC):
         lines = ""
         if process_stdout := process.stdout:
             current_rpt = None
-            while line := process_stdout.readline():
-                lines += line
-                log_file.write(line)
-                if self.step_dir is not None and line.startswith(REPORT_START_LOCUS):
-                    if current_rpt is not None:
-                        current_rpt.close()
-                    report_name = line[len(REPORT_START_LOCUS) + 1 :].strip()
-                    report_path = os.path.join(report_dir, report_name)
-                    current_rpt = open(report_path, "w")
-                elif line.startswith(REPORT_END_LOCUS):
-                    if current_rpt is not None:
-                        current_rpt.close()
-                    current_rpt = None
-                elif line.startswith(METRIC_LOCUS):
-                    command, name, value = line.split(" ", maxsplit=3)
-                    metric_type: Union[Type[str], Type[int], Type[float]] = str
-                    if command.endswith("_I"):
-                        metric_type = int
-                    elif command.endswith("_F"):
-                        metric_type = float
-                    generated_metrics[name] = metric_type(value)
-                elif current_rpt is not None:
-                    # No echo- the timing reports especially can be very large
-                    # and terminal emulators will slow the flow down.
-                    current_rpt.write(line)
-                elif not silent and "table template" not in line:  # sky130 ff hack
-                    logging.subprocess(line.strip())
+            try:
+                while line := process_stdout.readline():
+                    lines += line
+                    log_file.write(line)
+                    if self.step_dir is not None and line.startswith(
+                        REPORT_START_LOCUS
+                    ):
+                        if current_rpt is not None:
+                            current_rpt.close()
+                        report_name = line[len(REPORT_START_LOCUS) + 1 :].strip()
+                        report_path = os.path.join(report_dir, report_name)
+                        current_rpt = open(report_path, "w")
+                    elif line.startswith(REPORT_END_LOCUS):
+                        if current_rpt is not None:
+                            current_rpt.close()
+                        current_rpt = None
+                    elif line.startswith(METRIC_LOCUS):
+                        command, name, value = line.split(" ", maxsplit=3)
+                        metric_type: Union[Type[str], Type[int], Type[float]] = str
+                        if command.endswith("_I"):
+                            metric_type = int
+                        elif command.endswith("_F"):
+                            metric_type = float
+                        generated_metrics[name] = metric_type(value)
+                    elif current_rpt is not None:
+                        # No echo- the timing reports especially can be very large
+                        # and terminal emulators will slow the flow down.
+                        current_rpt.write(line)
+                    elif not silent and "table template" not in line:  # sky130 ff hack
+                        logging.subprocess(line.strip())
+            except UnicodeDecodeError as e:
+                raise StepException(f"Subprocess emitted non-UTF-8 output: {e}")
         process_stats_thread.join()
 
         json_stats = f"{os.path.splitext(log_path)[0]}.process_stats.json"


### PR DESCRIPTION
* `openlane.steps.Step`
  * Fixed `run_subprocess` crashing upon a tool outputting gibberish - a `StepException` is raised now

---

Fixes #226 