### PR TITLE
Add new CLI option(s) to save views to a particular folder

### DIFF
--- a/openlane/__main__.py
+++ b/openlane/__main__.py
@@ -22,7 +22,7 @@ from textwrap import dedent
 from functools import partial
 from typing import Sequence, Tuple, Type, Optional, List, Union
 
-from click import Parameter, pass_context
+from click import Parameter, pass_context, Path
 from cloup import (
     option,
     option_group,
@@ -67,6 +67,8 @@ def run(
     config_override_strings: List[str],
     _force_run_dir: Optional[str],
     design_dir: Optional[str],
+    view_save_path: Optional[str] = None,
+    ef_view_save_path: Optional[str] = None,
 ):
     try:
         if len(config_files) == 0:
@@ -132,7 +134,7 @@ def run(
         ctx.exit(1)
 
     try:
-        flow.start(
+        state_out = flow.start(
             tag=tag,
             last_run=last_run,
             frm=frm,
@@ -152,6 +154,11 @@ def run(
             err(f"The following error was encountered while running the flow: {e}")
         err("OpenLane will now quit.")
         ctx.exit(2)
+
+    if vsp := view_save_path:
+        state_out.save_snapshot(vsp)
+    if evsp := ef_view_save_path:
+        flow._save_snapshot_ef(evsp)
 
 
 def print_version(ctx: Context, param: Parameter, value: bool):
@@ -325,6 +332,23 @@ o = partial(option, show_default=True)
 @command(
     no_args_is_help=True,
     formatter_settings=formatter_settings,
+)
+@option_group(
+    "Copy final views",
+    o(
+        "--save-views-to",
+        "view_save_path",
+        type=Path(file_okay=False, dir_okay=True),
+        default=None,
+        help="A directory to copy the final views to, where each format is saved under a directory named after the corner ID (much like the 'final' directory after running a flow.)",
+    ),
+    o(
+        "--save-views-ef",
+        "ef_view_save_path",
+        type=Path(file_okay=False, dir_okay=True),
+        default=None,
+        help="A directory to copy the final views to in the Efabless format, compatible with Caravel User Project.",
+    ),
 )
 @option_group(
     "Containerization options",

--- a/openlane/common/generic_dict.py
+++ b/openlane/common/generic_dict.py
@@ -22,6 +22,7 @@ from typing import (
     Callable,
     Dict,
     Hashable,
+    ItemsView,
     Iterator,
     Mapping,
     Sequence,
@@ -176,7 +177,7 @@ class GenericDict(Mapping[KT, VT]):
         """
         return self.__data.values()
 
-    def items(self):
+    def items(self) -> ItemsView[KT, VT]:
         """
         :returns: A set-like object providing a view of the GenericDict object as (key, value) tuples.
         """

--- a/openlane/flows/flow.py
+++ b/openlane/flows/flow.py
@@ -461,6 +461,7 @@ class Flow(ABC):
         tag: Optional[str] = None,
         last_run: bool = False,
         _force_run_dir: Optional[str] = None,
+        _no_load_previous_steps: bool = False,
         **kwargs,
     ) -> State:
         """
@@ -527,9 +528,14 @@ class Flow(ABC):
             )
             for entry in entries_sorted:
                 components = entry.split("-", maxsplit=1)
-                self.step_objects.append(
-                    Step.load_finished(os.path.join(self.run_dir, entry))
-                )
+                if not _no_load_previous_steps:
+                    self.step_objects.append(
+                        Step.load_finished(
+                            os.path.join(self.run_dir, entry),
+                            self.config["PDK_ROOT"],
+                            self.Steps,
+                        )
+                    )
                 try:
                     extracted_ordinal = int(components[0])
                 except ValueError:

--- a/openlane/state/design_format.py
+++ b/openlane/state/design_format.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import os
 from enum import Enum
 from dataclasses import dataclass
 from typing import Dict, Optional
@@ -23,6 +24,9 @@ class DesignFormatObject:
     name: str
     folder_override: Optional[str] = None
     multiple: bool = False
+    _ef_format_dir: Optional[str] = None
+    _ef_format_replace_ext: Optional[str] = None
+    _ef_format_multicorner_add_default: bool = False
 
     @property
     def folder(self) -> str:
@@ -43,6 +47,8 @@ class DesignFormat(Enum):
         "pnl",
         "pnl.v",
         "Powered Verilog Netlist",
+        _ef_format_dir=os.path.join("verilog", "gl"),
+        _ef_format_replace_ext="v",
     )
     POWERED_NETLIST_SDF_FRIENDLY: DesignFormatObject = DesignFormatObject(
         "pnl-sdf-friendly",
@@ -61,11 +67,13 @@ class DesignFormat(Enum):
         "def",
         "def",
         "Design Exchange Format",
+        _ef_format_dir="def",
     )
     LEF: DesignFormatObject = DesignFormatObject(
         "lef",
         "lef",
         "Library Exchange Format",
+        _ef_format_dir="lef",
     )
     OPENROAD_LEF: DesignFormatObject = DesignFormatObject(
         "openroad-lef",
@@ -89,18 +97,24 @@ class DesignFormat(Enum):
         "sdf",
         "Standard Delay Format",
         multiple=True,
+        _ef_format_dir=os.path.join("sdf", "multicorner"),
+        _ef_format_multicorner_add_default=True,
     )
     SPEF: DesignFormatObject = DesignFormatObject(
         "spef",
         "spef",
         "Standard Parasitics Extraction Format",
         multiple=True,  # nom, min, max, ...
+        _ef_format_dir=os.path.join("spef", "multicorner"),
+        _ef_format_multicorner_add_default=True,
     )
     LIB: DesignFormatObject = DesignFormatObject(
         "lib",
         "lib",
         "LIB Timing Library Format",
         multiple=True,
+        _ef_format_dir=os.path.join("lib", "multicorner"),
+        _ef_format_multicorner_add_default=True,
     )
     SPICE: DesignFormatObject = DesignFormatObject(
         "spice",
@@ -112,12 +126,14 @@ class DesignFormat(Enum):
         "mag",
         "mag",
         "Magic VLSI View",
+        _ef_format_dir="spice",
     )
 
     GDS: DesignFormatObject = DesignFormatObject(
         "gds",
         "gds",
         "GDSII Stream",
+        _ef_format_dir="gds",
     )
     MAG_GDS: DesignFormatObject = DesignFormatObject(
         "mag_gds",


### PR DESCRIPTION
* Two new commandline flags added
  * `--save-views-to`: Saves all views to a directory in a structure after successful flow completion using `State.save_snapshot`
  * `--save-views-ef`: Saves all views to a directory in the Efabless format/convention, such as the one used by Caravel User Project.
* `openlane.flows`:
  * `Flow`
   * Added new instance variable, `config_resolved_path`, which contains the path to the `resolved.json` of a run
   * Flows resuming existing runs now load previously concluded steps into `self.step_objects` so they may be inspected
* `openlane.state`:
  * `DesignFormat`: Added a number of internal fields for the Efabless format/convention.
  * `State`: Internally unified traversal.
* `openlane.step`:
  * `Step`: Added new method `load_finished` to load concluded steps (including step directory and output state)
  * `Step.factory`: New method, `from_step_config`, which attempts to load a step from an input configuration file
  * Reworked step-loading functions to use `from_step_config` where appropriate

---
Resolves #262 