### PR TITLE
Testing Coverage Updates

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,8 +2,6 @@
 source = openlane
 
 [report]
-include =
-    openlane/*
 omit =
     /nix/*
     venv/
@@ -17,11 +15,13 @@ omit =
     */flows/classic.py
     */flows/misc.py
     */flows/optimizing.py
+    */flows/synth_explore.py
     */steps/klayout.py
     */steps/magic.py
     */steps/misc.py
     */steps/netgen.py
-    */steps/magic.py
+    */steps/odb.py
     */steps/openroad.py
     */steps/yosys.py
+    */steps/verilator.py
     */steps/cvc_rv.py

--- a/.coveragerc-steps
+++ b/.coveragerc-steps
@@ -1,0 +1,14 @@
+[run]
+source = openlane/steps
+
+[report]
+omit =
+    /nix/*
+    venv/
+    test_*.py
+    */steps/__main__.py
+    */steps/__init__.py
+    */steps/step.py
+    */steps/tclstep.py
+    */steps/checker.py
+    */steps/cvc_rv.py

--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,8 @@ slpp_all/
 
 # Testing
 .coverage
-htmlcov/
+.coverage.*
+htmlcov*/
 prof/
 sandbox/
 /designs

--- a/Makefile
+++ b/Makefile
@@ -45,17 +45,16 @@ lint: venv/manifest.txt
 	./venv/bin/flake8 .
 	./venv/bin/mypy --check-untyped-defs .
 
-.PHONY: test
-test: venv/manifest.txt
-	./venv/bin/coverage run -m pytest -n auto
-	./venv/bin/coverage report
-	./venv/bin/coverage html
+.PHONY: coverage-infrastructure
+coverage-infrastructure: venv/manifest.txt
+	./venv/bin/python3 -m pytest -n auto\
+		--cov=openlane --cov-config=.coveragerc --cov-report html:htmlcov_infra --cov-report term
 
-.PHONY: test-all
-test-all: venv/manifest.txt
-	./venv/bin/coverage run -m pytest --step-rx "." -n auto
-	./venv/bin/coverage report
-	./venv/bin/coverage html
+.PHONY: coverage-steps
+coverage-steps: venv/manifest.txt
+	./venv/bin/python3 -m pytest -n auto\
+		--cov=openlane.steps --cov-config=.coveragerc-steps --cov-report html:htmlcov_steps --cov-report term\
+		--step-rx "." -k test_all_steps
 
 .PHONY: check-license
 check-license: venv/manifest.txt

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -27,7 +27,7 @@ types-psutil
 # test
 pytest
 pytest-xdist
-coverage
+pytest-cov
 pyfakefs>=5.2.3,<6
 pillow>=10.0.1,<11
 


### PR DESCRIPTION
* Split code coverage scores into two: Infrastructure and Steps
* Replaced `coverage` with `pytest-cov`, which is compatible with `pytest-xdist`
* Reconfigured `make test`, `make test-all` as `make coverage-infrastructure` and `make coverage-steps`