### PR TITLE
Fix OpenROAD.GlobalPlacementSkipIO sometimes not using correct util

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -374,7 +374,7 @@ jobs:
             require("./.github/scripts/post_metrics.js")(
               github,
               context,
-              "github-actions[bot]",
+              "${{ vars.BOT_USERNAME }}",
               "${{ secrets.GH_TOKEN }}",
             ).then(()=>{console.log("Done.");});
       - name: "[Push] Upload Metrics"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -374,7 +374,7 @@ jobs:
             require("./.github/scripts/post_metrics.js")(
               github,
               context,
-              "openlane-bot",
+              "github-actions[bot]",
               "${{ secrets.GH_TOKEN }}",
             ).then(()=>{console.log("Done.");});
       - name: "[Push] Upload Metrics"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -374,7 +374,7 @@ jobs:
             require("./.github/scripts/post_metrics.js")(
               github,
               context,
-              "${{ vars.BOT_USERNAME }}",
+              "github-actions[bot]",
               "${{ secrets.GH_TOKEN }}",
             ).then(()=>{console.log("Done.");});
       - name: "[Push] Upload Metrics"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -374,7 +374,7 @@ jobs:
             require("./.github/scripts/post_metrics.js")(
               github,
               context,
-              "github-actions[bot]",
+              "openlane-bot",
               "${{ secrets.GH_TOKEN }}",
             ).then(()=>{console.log("Done.");});
       - name: "[Push] Upload Metrics"

--- a/openlane/steps/openroad.py
+++ b/openlane/steps/openroad.py
@@ -1070,29 +1070,13 @@ class GlobalPlacementSkipIO(GlobalPlacement):
 
     def run(self, state_in: State, **kwargs) -> Tuple[ViewsUpdate, MetricsUpdate]:
         kwargs, env = self.extract_env(kwargs)
-        if self.config["FP_IO_MODE"] == "random_equidistant":
-            info(
-                "FP_IO_MODE set to 'random_equidistant'. Skipping the first global placement iteration…"
-            )
-            return {}, {}
-        elif self.config["PL_TARGET_DENSITY_PCT"] is None:
-            expr = (
-                self.config["FP_CORE_UTIL"] + (5 * self.config["GPL_CELL_PADDING"]) + 10
-            )
-            expr = min(expr, 100)
-            env["PL_TARGET_DENSITY_PCT"] = f"{expr}"
-            warn(
-                f"'PL_TARGET_DENSITY_PCT' not explicitly set, using dynamically calculated target density: {expr}…"
-            )
-        env["__PL_SKIP_IO"] = "1"
-
         if self.config["FP_DEF_TEMPLATE"] is not None:
             info(
                 f"I/O pins were loaded from {self.config['FP_DEF_TEMPLATE']}. Skipping the first global placement iteration…"
             )
             return {}, {}
-
-        return OpenROADStep.run(self, state_in, env=env, **kwargs)
+        env["__PL_SKIP_IO"] = "1"
+        return super().run(state_in, env=env, **kwargs)
 
 
 @Step.factory.register()


### PR DESCRIPTION
* `OpenROAD.GlobalPlacementSkipIO`:
    * Fixed a bug where `PL_TARGET_DENSITY_PCT` is calculated base on `FP_CORE_UTIL`
    in designs with `FP_SIZING` set to `absolute`. The behavior now matches
    `OpenROAD.GlobalPlacement`.