### PR TITLE
Update Nix Installation instruction link in the Newcomers' guide

### DIFF
--- a/docs/source/getting_started/migrants/index.md
+++ b/docs/source/getting_started/migrants/index.md
@@ -69,7 +69,7 @@ The Nix method involves installing the Nix build utility/package management
 software and cloning the OpenLane repository.
 
 You can install Nix and set up the OpenLane binary cache by following the
-instructions at {ref}`nix-based-installation`
+instructions at {ref}`nix-based-installation`.
 
 Afterwards, you can run an example as follows:
 

--- a/docs/source/getting_started/newcomers/index.md
+++ b/docs/source/getting_started/newcomers/index.md
@@ -108,7 +108,7 @@ ______________________________________________________________________
 
 ## Installation
 
-1. Follow the instructions [here](https://app.cachix.org/cache/openlane) to
+1. Follow the instructions in {ref}`nix-based-installation` to
    install {term}`Nix` and set up {term}`Cachix`.
 
 1. Open a terminal and clone OpenLane as follows:


### PR DESCRIPTION
## Documentation

* Replaced Cachix's Nix installation guide with our Nix-based Installation guide in the Newcomers' Guide