### PR TITLE
Update pm32.v

### DIFF
--- a/docs/source/getting_started/newcomers/pm32.v
+++ b/docs/source/getting_started/newcomers/pm32.v
@@ -64,7 +64,7 @@ module pm32 (
 
     wire y = (state==RUNNING) ? Y[0] : 1'b0;
 
-    spm #(.size(32)) spm32(
+    spm #(.SIZE(32)) spm32(
         .clk(clk),
         .rst(rst),
         .x(mc),


### PR DESCRIPTION
Was just running through this part of the docs and ran into an error after running `openlane` on the example:

```
 4847 | module sky130_fd_sc_hd__xor3_4(X, A, B, C);
      |        ^~~~~~~~~~~~~~~~~~~~~~~
                       /home/calvin/hardwaredev/pm32/pm32.v:8:8: ... Location of module with timescale
    8 | module pm32 (
      |        ^~~~
%Error-PINNOTFOUND: /home/calvin/hardwaredev/pm32/pm32.v:67:12: Parameter not found: 'size'
   67 |     spm #(.size(32)) spm32(
      |            ^~~~
%Error: Exiting due to 1 error(s)

Log file: '../hardwaredev/pm32/runs/RUN_2024-03-01_16-09-27/01-verilator-lint/verilator-lint.log'
1 Lint errors found.

```

Changing this fixed the issue and the flow ran smoothly afterwards.