### PR TITLE
Fix reproducibles for steps with `run_subprocess` overrides

### DIFF
--- a/openlane/steps/step.py
+++ b/openlane/steps/step.py
@@ -1040,6 +1040,7 @@ class Step(ABC):
         silent: bool = False,
         report_dir: Optional[Union[str, os.PathLike]] = None,
         env: Optional[Dict[str, Any]] = None,
+        _popen_callable: Callable[..., psutil.Popen] = psutil.Popen,
         **kwargs,
     ) -> Dict[str, Any]:
         """
@@ -1107,7 +1108,7 @@ class Step(ABC):
                     f"Environment variable for key '{key}' is of invalid type {type(value)}: {value}"
                 )
 
-        process = psutil.Popen(
+        process = _popen_callable(
             cmd_str,
             encoding="utf8",
             env=env,

--- a/openlane/steps/tclstep.py
+++ b/openlane/steps/tclstep.py
@@ -241,6 +241,7 @@ class TclStep(Step):
                 "PATH",
                 "PYTHONPATH",
                 "SCRIPTS_DIR",
+                "DESIGN_DIR",
                 "STEP_DIR",
                 "PDK_ROOT",
                 "PDK",


### PR DESCRIPTION
* `TclStep`
  * `DESIGN_DIR` moved from `_TCL_ENV_IN` to the environment proper

## CLI
* `openlane.steps`
  * `eject` *now overrides `psutils.Popen()` instead of `run_subprocess`, allowing it to run at a lower level * `PATH`, `PYTHONPATH` now excluded from `run.sh`

---

Resolves #156
Resolves #417 