### PR TITLE
Fix args not propagated to configure_cts_characterization

### DIFF
--- a/openlane/scripts/openroad/cts.tcl
+++ b/openlane/scripts/openroad/cts.tcl
@@ -27,9 +27,9 @@ repair_clock_inverters
 
 puts "\[INFO\] Configuring cts characterization…"
 set cts_characterization_args [list]
-lappend -max_cap [expr {$::env(CTS_MAX_CAP) * 1e-12}]; # pF -> F
+lappend cts_characterization_args -max_cap [expr {$::env(CTS_MAX_CAP) * 1e-12}]; # pF -> F
 if { [info exists ::env(MAX_TRANSITION_CONSTRAINT)] } {
-    lappend -max_slew [expr {$::env(MAX_TRANSITION_CONSTRAINT) * 1e-9}]; # ns -> S
+    lappend cts_characterization_args -max_slew [expr {$::env(MAX_TRANSITION_CONSTRAINT) * 1e-9}]; # ns -> S
 }
 configure_cts_characterization {*}$cts_characterization_args
 


### PR DESCRIPTION
* `OpenROAD.CTS`
  * Fixed issue where no arguments were passed to `configure_cts_characterization`