### PR TITLE
Fix Logic Mixup

### DIFF
--- a/openlane/scripts/magic/lef.tcl
+++ b/openlane/scripts/magic/lef.tcl
@@ -41,7 +41,7 @@ lef nocheck $::env(VDD_NETS) $::env(GND_NETS)
 
 # Write LEF
 set lefwrite_opts [list]
-if { !$::env(MAGIC_WRITE_FULL_LEF) } {
+if { $::env(MAGIC_WRITE_FULL_LEF) } {
     puts "\[INFO] Writing non-abstract (full) LEF…"
 } else {
     lappend lefwrite_opts -hide


### PR DESCRIPTION
* `Magic.WriteLEF`
  * Fixed bug where `MAGIC_WRITE_FULL_LEF` had its logic inverted

---

Resolves #428 

---

Just to be clear, this is my fault; despite the blame showing Sylvain.