### PR TITLE
Macro Verilog Name Consistency

### DIFF
--- a/docs/source/usage/using_macros.md
+++ b/docs/source/usage/using_macros.md
@@ -156,6 +156,17 @@ would be declared as:
   }
 ```
 
+```{admonition} On Instance Names
+:class: tip
+
+Instance names should match the name as instantiated in Verilog, i.e.,
+without escaping any characters for layout formats.
+
+For example, if you instantiate an array of macros `spm spm_inst[1:0]`,
+the first instance's name should be `spm_inst[0]`, not
+`spm_inst\[0\]` or similar.
+```
+
 ## STA
 
 Without certain files, STA is performed in what is known as **black-boxed**

--- a/openlane/flows/flow.py
+++ b/openlane/flows/flow.py
@@ -463,6 +463,8 @@ class Flow(ABC):
         last_run: bool = False,
         _force_run_dir: Optional[str] = None,
         _no_load_previous_steps: bool = False,
+        *,
+        overwrite: bool = False,
         **kwargs,
     ) -> State:
         """
@@ -483,6 +485,8 @@ class Flow(ABC):
 
             If ``last_run`` and ``tag`` are both set, a :class:`FlowException` will
             also be raised.
+        :param overwrite: If true and a run with the desired tag was found, the
+            contents will be deleted instead of appended.
 
         :returns: ``(success, state_list)``
         """
@@ -530,6 +534,10 @@ class Flow(ABC):
             entries = os.listdir(self.run_dir)
             if len(entries) == 0:
                 raise FileNotFoundError(self.run_dir)  # Treat as non-existent directory
+            elif overwrite:
+                shutil.rmtree(self.run_dir)
+                raise FileNotFoundError(self.run_dir)  # Treat as non-existent directory
+
             info(f"Using existing run at '{tag}' with the '{self.name}' flow.")
 
             # Extract maximum step ordinal + load finished steps

--- a/openlane/scripts/odbpy/manual_macro_place.py
+++ b/openlane/scripts/odbpy/manual_macro_place.py
@@ -68,11 +68,15 @@ def manual_macro_place(reader, config, fixed):
             if not line:
                 continue
             line = line.split()
-            macros[line[0]] = [
-                str(int(float(line[1]) * db_units_per_micron)),
-                str(int(float(line[2]) * db_units_per_micron)),
-                line[3],
+            name, x, y, orientation = line
+            macro_data = [
+                name,
+                int(float(x) * db_units_per_micron),
+                int(float(y) * db_units_per_micron),
+                orientation,
             ]
+            name_escaped = reader.escape_verilog_name(name)
+            macros[name_escaped] = macro_data
 
     print("Placing the following macros:")
     print(macros)
@@ -88,9 +92,10 @@ def manual_macro_place(reader, config, fixed):
         if inst_name in macros:
             print("Placing", inst_name)
             macro_data = macros[inst_name]
-            x = gridify(int(macro_data[0]), 5)
-            y = gridify(int(macro_data[1]), 5)
-            inst.setOrient(lef_rot_to_oa_rot(macro_data[2]))
+            _, x, y, orientation = macro_data
+            x = gridify(x, 5)
+            y = gridify(y, 5)
+            inst.setOrient(lef_rot_to_oa_rot(orientation))
             inst.setLocation(x, y)
             if fixed:
                 inst.setPlacementStatus("FIRM")
@@ -100,8 +105,8 @@ def manual_macro_place(reader, config, fixed):
 
     if len(macros):
         print("Declared macros not instantiated in design:", file=sys.stderr)
-        for macro in macros:
-            print(f"* {macro}", file=sys.stderr)
+        for macro in macros.value():
+            print(f"* {macro[0]}", file=sys.stderr)
         exit(1)
 
     print(f"Successfully placed {macros_cnt} instances.")

--- a/openlane/scripts/odbpy/reader.py
+++ b/openlane/scripts/odbpy/reader.py
@@ -87,9 +87,7 @@ class OdbReader(object):
 
         busbitchars = re.escape("[]")  # TODO: Get alternatives from LEF parser
         dividerchar = re.escape("/")  # TODO: Get alternatives from LEF parser
-        self.escape_verilog_rx = re.compile(
-            rf"([{re.escape(dividerchar + busbitchars)}])"
-        )
+        self.escape_verilog_rx = re.compile(rf"([{dividerchar + busbitchars}])")
 
     def add_lef(self, new_lef):
         self.ord_tech.readLef(new_lef)

--- a/openlane/scripts/odbpy/reader.py
+++ b/openlane/scripts/odbpy/reader.py
@@ -14,13 +14,14 @@
 # flake8: noqa E402
 import odb
 import json
-from fnmatch import fnmatch
 from openroad import Tech, Design
 
+import re
 import sys
 import locale
 import inspect
 import functools
+from fnmatch import fnmatch
 from typing import Callable, Dict
 
 # -- START: Environment Fixes
@@ -84,8 +85,17 @@ class OdbReader(object):
             self.dbunits = self.block.getDefUnits()
             self.instances = self.block.getInsts()
 
+        busbitchars = re.escape("[]")  # TODO: Get alternatives from LEF parser
+        dividerchar = re.escape("/")  # TODO: Get alternatives from LEF parser
+        self.escape_verilog_rx = re.compile(
+            rf"([{re.escape(dividerchar + busbitchars)}])"
+        )
+
     def add_lef(self, new_lef):
         self.ord_tech.readLef(new_lef)
+
+    def escape_verilog_name(self, name_in: str) -> str:
+        return self.escape_verilog_rx.sub(r"\\\1", name_in)
 
     def _dpl(self):
         """

--- a/openlane/steps/openroad.py
+++ b/openlane/steps/openroad.py
@@ -399,6 +399,7 @@ class CheckMacroInstances(STAPrePNR):
     """
 
     id = "OpenROAD.CheckMacroInstances"
+    name = "Check Macro Instances"
     outputs = []
 
     config_vars = OpenROADStep.config_vars


### PR DESCRIPTION
* `OpenROAD.ManualMacroPlacement`
  * **API Break**: Verilog names of macros are now considered instead of DEF names in the event of a mismatch (e.g. for instances with `[]` or `/` in the name.)

## Misc
* `openlane.flows`
  * `Flow` 
    * `.start()` now supports new keyword argument `overwrite` that deletes run directories if they are non-empty

---
Depends on https://github.com/efabless/openlane2-ci-designs/pull/24
Resolves #409 
