### PR TITLE
Fix Caravel Issues

### DIFF
--- a/openlane/common/toolbox.py
+++ b/openlane/common/toolbox.py
@@ -391,7 +391,7 @@ class Toolbox(object):
 
     def create_blackbox_model(
         self,
-        input_models: FrozenSet[str],
+        input_models: Union[frozenset, Tuple[str, ...]],
         defines: FrozenSet[str],
     ) -> str:
         mkdirp(self.tmp_dir)

--- a/openlane/scripts/openroad/cts.tcl
+++ b/openlane/scripts/openroad/cts.tcl
@@ -27,9 +27,11 @@ repair_clock_inverters
 
 puts "\[INFO\] Configuring cts characterization…"
 set cts_characterization_args [list]
-lappend cts_characterization_args -max_cap [expr {$::env(CTS_MAX_CAP) * 1e-12}]; # pF -> F
-if { [info exists ::env(MAX_TRANSITION_CONSTRAINT)] } {
-    lappend cts_characterization_args -max_slew [expr {$::env(MAX_TRANSITION_CONSTRAINT) * 1e-9}]; # ns -> S
+if { [info exists ::env(CTS_MAX_CAP)] } {
+    lappend cts_characterization_args -max_cap [expr {$::env(CTS_MAX_CAP) * 1e-12}]; # pF -> F
+}
+if { [info exists ::env(CTS_MAX_SLEW)] } {
+    lappend cts_characterization_args -max_slew [expr {$::env(CTS_MAX_SLEW) * 1e-9}]; # ns -> S
 }
 configure_cts_characterization {*}$cts_characterization_args
 

--- a/openlane/steps/openroad.py
+++ b/openlane/steps/openroad.py
@@ -1806,10 +1806,15 @@ class CTS(ResizerStep):
             ),
             Variable(
                 "CTS_MAX_CAP",
-                Decimal,
-                "Defines the maximum capacitance, used in CTS.",
+                Optional[Decimal],
+                "Overrides the maximum capacitance used in CTS.",
                 units="pF",
-                pdk=True,
+            ),
+            Variable(
+                "CTX_MAX_SLEW",
+                Optional[Decimal],
+                "Overrides the maximum transition time used in CTS.",
+                units="ns",
             ),
         ]
     )

--- a/openlane/steps/openroad.py
+++ b/openlane/steps/openroad.py
@@ -1807,13 +1807,13 @@ class CTS(ResizerStep):
             Variable(
                 "CTS_MAX_CAP",
                 Optional[Decimal],
-                "Overrides the maximum capacitance used in CTS.",
+                "Overrides the maximum capacitance CTS characterization will test. If omitted, the capacitance is extracted from the lib information of the buffers in CTS_CLK_BUFFERS.",
                 units="pF",
             ),
             Variable(
-                "CTX_MAX_SLEW",
+                "CTS_MAX_SLEW",
                 Optional[Decimal],
-                "Overrides the maximum transition time used in CTS.",
+                "Overrides the maximum transition time CTS characterization will test. If omitted, the slew is extracted from the lib information of the buffers in CTS_CLK_BUFFERS.",
                 units="ns",
             ),
         ]


### PR DESCRIPTION
* `OpenROAD.CTS`
  * Made `CTS_MAX_CAP` a non-PDK value, and also optional as the values in the PDKs are bad and OpenROAD does a better job without it
  * CTS no longer passes `MAX_TRANSITION_CONSTRAINT`, instead using a new variable `CTS_MAX_SLEW` if it exists

* `Verilator.Lint`
  * Fixed issue where the order of files may not be preserved for macros

---

Issues reported by @mo-hosni 