### PR TITLE
Update KLayout

### DIFF
--- a/nix/klayout.nix
+++ b/nix/klayout.nix
@@ -42,14 +42,13 @@
   gcc,
   libgit2,
 }:
-clangStdenv.mkDerivation {
+clangStdenv.mkDerivation rec {
   name = "klayout";
+  version = "0.28.17-1";
 
-  src = fetchFromGitHub {
-    owner = "KLayout";
-    repo = "klayout";
-    rev = "5961eab84bd2d394f3ca94f9482622180d796010";
-    sha256 = "sha256-omeWS72J6mbA5mxsqwmsq1ytuhHa0rLZ+ErN66o+fiY=";
+  src = fetchTarball {
+    url = "https://github.com/KLayout/klayout/archive/refs/tags/v${version}.tar.gz";
+    sha256 = "sha256:0c2jm0n3vm4wyk25wpi1dlv00qnjqdmgpjmchv0hc5ysx47a2y6a";
   };
 
   patches = [
@@ -90,6 +89,8 @@ clangStdenv.mkDerivation {
       then "1"
       else "0"
     }" = "1" ]; then
+      export MAC_LIBGIT2_INC="${libgit2}/include"
+      export MAC_LIBGIT2_LIB="${libgit2}/lib"
       export LDFLAGS="-headerpad_max_install_names"
     fi
     ./build.sh\

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ libparse>=0.3.1,<1
 psutil>=5.9.0
 httpx>=0.22.0, <0.28
 ioplace_parser~=0.1.0
-klayout==0.28.15
+klayout>=0.28.17.post1,<0.29.0

--- a/test/common/test_tcl.py
+++ b/test/common/test_tcl.py
@@ -17,7 +17,7 @@ import tkinter
 from pyfakefs.fake_filesystem_unittest import Patcher
 
 
-@pytest.fixture()
+@pytest.fixture
 def _mock_fs():
     with Patcher() as patcher:
         patcher.fs.create_dir("/cwd")

--- a/test/common/test_toolbox.py
+++ b/test/common/test_toolbox.py
@@ -20,7 +20,7 @@ import pytest
 from pyfakefs.fake_filesystem_unittest import Patcher
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_macros_config():
     from openlane.config import Macro, Instance
 
@@ -71,7 +71,7 @@ def mock_macros_config():
     }
 
 
-@pytest.fixture()
+@pytest.fixture
 def sample_lib_files():
     return {
         "example_lib.lib": textwrap.dedent(
@@ -147,7 +147,7 @@ def sample_lib_files():
     }
 
 
-@pytest.fixture()
+@pytest.fixture
 def _lib_mock_fs(sample_lib_files):
     with Patcher() as patcher:
         patcher.fs.create_dir("/cwd")
@@ -169,7 +169,7 @@ def _lib_mock_fs(sample_lib_files):
         yield
 
 
-@pytest.fixture()
+@pytest.fixture
 def lib_trim_result():
     return [
         textwrap.dedent(
@@ -218,7 +218,7 @@ def lib_trim_result():
     ]
 
 
-@pytest.fixture()
+@pytest.fixture
 def model_blackboxing():
     start = textwrap.dedent(
         """

--- a/test/config/test_variable.py
+++ b/test/config/test_variable.py
@@ -19,7 +19,7 @@ from pyfakefs.fake_filesystem_unittest import Patcher
 from typing import Dict, List, Literal, Optional, Tuple, Type, Union
 
 
-@pytest.fixture()
+@pytest.fixture
 def _mock_fs():
     with Patcher() as patcher:
         patcher.fs.create_dir("/cwd")
@@ -162,7 +162,7 @@ def test_variable_construction():
     ), "Union magically switched types"
 
 
-@pytest.fixture()
+@pytest.fixture
 def variable():
     from openlane.common import Path
     from openlane.config import Variable
@@ -251,7 +251,7 @@ def test_compile_deprecated(variable):
     assert len(warning_list) == 1, "use of deprecated names did not produce a warning"
 
 
-@pytest.fixture()
+@pytest.fixture
 def test_enum():
     from enum import IntEnum
 
@@ -262,7 +262,7 @@ def test_enum():
     return TestEnum
 
 
-@pytest.fixture()
+@pytest.fixture
 def variable_set(variable, test_enum):
     from openlane.config import Variable
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -40,7 +40,7 @@ def pytest_assertrepr_compare(op, left, right):
         return return_value
 
 
-@pytest.fixture()
+@pytest.fixture
 def _mock_conf_fs():
     with Patcher() as patcher:
         rmtree("/run", ignore_errors=True)
@@ -125,7 +125,7 @@ class chdir_tmp(chdir):
         self.path = None
 
 
-@pytest.fixture()
+@pytest.fixture
 def _chdir_tmp(request: SubRequest):
     keep_tmp = request.config.getoption("--keep-tmp")
     import tempfile
@@ -262,7 +262,7 @@ def mock_variables(patch_in_objects: Optional[Iterable[Any]] = None):
     return decorator
 
 
-@pytest.fixture()
+@pytest.fixture
 @mock_variables()
 def mock_config():
     from openlane.config import Config

--- a/test/flows/test_flow.py
+++ b/test/flows/test_flow.py
@@ -25,12 +25,12 @@ from openlane.steps import step
 mock_variables = pytest.mock_variables
 
 
-@pytest.fixture()
+@pytest.fixture
 def variable():
     return Variable("DUMMY_VARIABLE", type=str, description="x")
 
 
-@pytest.fixture()
+@pytest.fixture
 def MockStepTuple(variable: Variable):
     from openlane.common import Path
     from openlane.steps import Step
@@ -104,7 +104,7 @@ def MockStepTuple(variable: Variable):
     return (StepA, StepB, StepC)
 
 
-@pytest.fixture()
+@pytest.fixture
 def DummyFlow(MockStepTuple):
     from openlane.flows import Flow
 

--- a/test/flows/test_sequential.py
+++ b/test/flows/test_sequential.py
@@ -22,7 +22,7 @@ from openlane.steps import Step, step as step_module
 mock_variables = pytest.mock_variables
 
 
-@pytest.fixture()
+@pytest.fixture
 def MetricIncrementer():
     from openlane.steps import Step
 

--- a/test/state/test_state.py
+++ b/test/state/test_state.py
@@ -18,7 +18,7 @@ import pytest
 from pyfakefs.fake_filesystem_unittest import Patcher
 
 
-@pytest.fixture()
+@pytest.fixture
 def _mock_fs():
     with Patcher() as patcher:
         patcher.fs.create_dir("/cwd")

--- a/test/steps/test_all_steps.py
+++ b/test/steps/test_all_steps.py
@@ -23,14 +23,14 @@ import pytest
 from _pytest.fixtures import SubRequest
 
 
-@pytest.fixture()
+@pytest.fixture
 def _step_enabled(request: SubRequest, test: str):
     step_rx = request.config.option.step_rx
     if re.search(step_rx, test) is None:
         pytest.skip()
 
 
-@pytest.fixture()
+@pytest.fixture
 def pdk_root(request):
     import volare
     from openlane.common import get_opdks_rev

--- a/test/steps/test_checker.py
+++ b/test/steps/test_checker.py
@@ -18,7 +18,7 @@ from openlane.steps import step
 mock_variables = pytest.mock_variables
 
 
-@pytest.fixture()
+@pytest.fixture
 def PotatoesBurnt():
     from openlane.steps.checker import MetricChecker
 
@@ -33,7 +33,7 @@ def PotatoesBurnt():
     return PotatoesBurnt
 
 
-@pytest.fixture()
+@pytest.fixture
 def run_potato_checker(PotatoesBurnt, mock_config):
     def impl(state_in):
         from openlane.common import Toolbox

--- a/test/steps/test_step.py
+++ b/test/steps/test_step.py
@@ -22,7 +22,7 @@ from openlane.steps import step
 mock_variables = pytest.mock_variables
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_run():
     def run(self, state_in, **kwargs):
         views_update = {}


### PR DESCRIPTION
## Tool Updates

* Updated KLayout to `0.28.17-1`
  * Relaxes PIP version range to accept newer patches (not newer minor versions)

## Testing
* Updated tests because newer versions of flake8 hate `pytest.fixture()` for some reason

---

The motivation behind this is that KLayout will delete older patches when they run out of PIP space. This broke OpenLane 2 for everyone as we pin the KLayout version used. See https://github.com/KLayout/klayout/issues/1670 for more info.