### PR TITLE
Move some Pin-Placament Variables to PDK

### DIFF
--- a/openlane/config/pdk_compat.py
+++ b/openlane/config/pdk_compat.py
@@ -138,6 +138,9 @@ def migrate_old_config(config: Mapping[str, Any]) -> Dict[str, Any]:
         new["CLOCK_TRANSITION_CONSTRAINT"] = 0.15
         new["TIME_DERATING_CONSTRAINT"] = 5
         new["IO_DELAY_CONSTRAINT"] = 20
+        new["FP_IO_MIN_DISTANCE"] = 3
+        new["FP_IO_HLENGTH"] = 4
+        new["FP_IO_VLENGTH"] = 4
 
     # 8. "Implicit" Paths
     if new["PDK"].startswith("sky130") or new["PDK"].startswith("gf180mcu"):

--- a/openlane/scripts/odbpy/io_place.py
+++ b/openlane/scripts/odbpy/io_place.py
@@ -266,15 +266,25 @@ def io_place(
     if hor_length is not None:
         H_LENGTH = int(micron_in_units * hor_length)
     else:
-        H_LENGTH = int(
-            math.ceil(H_LAYER.getArea() * micron_in_units * micron_in_units / H_WIDTH)
+        H_LENGTH = max(
+            int(
+                math.ceil(
+                    H_LAYER.getArea() * micron_in_units * micron_in_units / H_WIDTH
+                )
+            ),
+            H_WIDTH,
         )
 
     if ver_length is not None:
         V_LENGTH = int(micron_in_units * ver_length)
     else:
-        V_LENGTH = int(
-            math.ceil(V_LAYER.getArea() * micron_in_units * micron_in_units / V_WIDTH)
+        V_LENGTH = max(
+            int(
+                math.ceil(
+                    V_LAYER.getArea() * micron_in_units * micron_in_units / V_WIDTH
+                )
+            ),
+            V_WIDTH,
         )
 
     # read config + calculate minima

--- a/openlane/scripts/openroad/ioplacer.tcl
+++ b/openlane/scripts/openroad/ioplacer.tcl
@@ -18,14 +18,20 @@ if { [info exists ::env(CONTEXTUAL_IO_FLAG)] } {
 	read_lef $::env(placement_tmpfiles)/top_level.lef
 }
 
-if {$::env(FP_IO_HLENGTH) != "" && $::env(FP_IO_HLENGTH) != ""} {
-	set_pin_length -hor_length $::env(FP_IO_HLENGTH) \
-		-ver_length $::env(FP_IO_VLENGTH)
+if { [info exists ::env(FP_IO_HLENGTH)] } {
+	set_pin_length -hor_length $::env(FP_IO_HLENGTH)
 }
 
-if {$::env(FP_IO_HEXTEND) != "0" && $::env(FP_IO_VEXTEND) != "0"} {
-	set_pin_length_extension -hor_extension $::env(FP_IO_HEXTEND) \
-		-ver_extension $::env(FP_IO_VEXTEND)
+if { [info exists ::env(FP_IO_VLENGTH)] } {
+	set_pin_length -ver_length $::env(FP_IO_VLENGTH)
+}
+
+if { $::env(FP_IO_HEXTEND) != "0"} {
+	set_pin_length_extension -hor_extension $::env(FP_IO_HEXTEND)
+}
+
+if { $::env(FP_IO_VEXTEND) != "0"} {
+	set_pin_length_extension -ver_extension $::env(FP_IO_VEXTEND)
 }
 
 if {$::env(FP_IO_VTHICKNESS_MULT) != "" && $::env(FP_IO_HTHICKNESS_MULT) != ""} {
@@ -38,12 +44,12 @@ if { $::env(FP_IO_MODE) == "random_equidistant" } {
 	lappend arg_list -random
 }
 
-if { $::env(FP_IO_MIN_DISTANCE) != "" } {
+if { [info exists ::env(FP_IO_MIN_DISTANCE)] } {
 	lappend arg_list -min_distance $::env(FP_IO_MIN_DISTANCE)
 }
 
 if { $::env(FP_IO_MODE) == "annealing" } {
-    lappend arg_list -annealing
+	lappend arg_list -annealing
 }
 
 set HMETAL $::env(FP_IO_HLAYER)

--- a/openlane/steps/common_variables.py
+++ b/openlane/steps/common_variables.py
@@ -32,20 +32,6 @@ io_layer_variables = [
         units="µm",
     ),
     Variable(
-        "FP_IO_VLENGTH",
-        Decimal,
-        "The length of the vertical IOs.",
-        default=4,
-        units="µm",
-    ),
-    Variable(
-        "FP_IO_HLENGTH",
-        Decimal,
-        "The length of the horizontal IOs.",
-        default=4,
-        units="µm",
-    ),
-    Variable(
         "FP_IO_VTHICKNESS_MULT",
         Decimal,
         "A multiplier for vertical pin thickness. Base thickness is the pins layer min width.",

--- a/openlane/steps/odb.py
+++ b/openlane/steps/odb.py
@@ -579,14 +579,22 @@ class CustomIOPlacement(OdbpyStep):
         Variable(
             "FP_IO_VLENGTH",
             Optional[Decimal],
-            "The length of the pins with a north or south orientation. If unspecified by a PDK, the script will use the minimum value satisfying the minimum area constraint for the pin layer given the width (which is the minimum width for that routing layer).",
+            """
+            The length of the pins with a north or south orientation. If unspecified by a PDK, the script will use whichever is higher of the following two values:
+                * The pin width
+                * The minimum value satisfying the minimum area constraint given the pin width
+            """,
             units="µm",
             pdk=True,
         ),
         Variable(
             "FP_IO_HLENGTH",
             Optional[Decimal],
-            "The length of the pins with a east or west orientation. If unspecified by a PDK, the script will use the minimum value satisfying the minimum area constraint for the pin layer given the width (which is the minimum width for that routing layer * the thickness multiplier).",
+            """
+            The length of the pins with an east or west orientation. If unspecified by a PDK, the script will use whichever is higher of the following two values:
+                * The pin width
+                * The minimum value satisfying the minimum area constraint given the pin width
+            """,
             units="µm",
             pdk=True,
         ),

--- a/openlane/steps/openroad.py
+++ b/openlane/steps/openroad.py
@@ -872,10 +872,10 @@ class IOPlacement(OpenROADStep):
             ),
             Variable(
                 "FP_IO_MIN_DISTANCE",
-                Decimal,
-                "The minimum distance between the IOs.",
-                default=3,
+                Optional[Decimal],
+                "The minimum distance between two pins. If unspecified by a PDK, OpenROAD will use the length of two routing tracks.",
                 units="µm",
+                pdk=True,
             ),
             Variable(
                 "FP_PIN_ORDER_CFG",
@@ -886,6 +886,20 @@ class IOPlacement(OpenROADStep):
                 "FP_DEF_TEMPLATE",
                 Optional[Path],
                 "Points to the DEF file to be used as a template.",
+            ),
+            Variable(
+                "FP_IO_VLENGTH",
+                Optional[Decimal],
+                "The length of the pins with a north or south orientation. If unspecified by a PDK, OpenROAD will use the minimum value satisfying the minimum area constraint for the pin layer given the width (which is the minimum width for that routing layer).",
+                units="µm",
+                pdk=True,
+            ),
+            Variable(
+                "FP_IO_HLENGTH",
+                Optional[Decimal],
+                "The length of the pins with a east or west orientation. If unspecified by a PDK, OpenROAD will use the minimum value satisfying the minimum area constraint for the pin layer given the width (which is the minimum width for that routing layer * the thickness multiplier).",
+                units="µm",
+                pdk=True,
             ),
         ]
     )

--- a/openlane/steps/openroad.py
+++ b/openlane/steps/openroad.py
@@ -958,14 +958,22 @@ class IOPlacement(OpenROADStep):
             Variable(
                 "FP_IO_VLENGTH",
                 Optional[Decimal],
-                "The length of the pins with a north or south orientation. If unspecified by a PDK, OpenROAD will use the minimum value satisfying the minimum area constraint for the pin layer given the width (which is the minimum width for that routing layer).",
+                """
+                The length of the pins with a north or south orientation. If unspecified by a PDK, OpenROAD will use whichever is higher of the following two values:
+                    * The pin width
+                    * The minimum value satisfying the minimum area constraint given the pin width
+                """,
                 units="µm",
                 pdk=True,
             ),
             Variable(
                 "FP_IO_HLENGTH",
                 Optional[Decimal],
-                "The length of the pins with a east or west orientation. If unspecified by a PDK, OpenROAD will use the minimum value satisfying the minimum area constraint for the pin layer given the width (which is the minimum width for that routing layer * the thickness multiplier).",
+                """
+                The length of the pins with an east or west orientation. If unspecified by a PDK, OpenROAD will use whichever is higher of the following two values:
+                    * The pin width
+                    * The minimum value satisfying the minimum area constraint given the pin width
+                """,
                 units="µm",
                 pdk=True,
             ),


### PR DESCRIPTION
* `OpenROAD.IOPlacement`
  * `FP_IO_VLENGTH`, `FP_IO_HLENGTH`, `FP_IO_MIN_DISTANCE` are now all optional PDK variables
    * For PDKs that do not specify them, OpenROAD calculates default values based on the layers' rules

 * `OpenROAD.CustomIOPlacement`
   * `FP_IO_VLENGTH`, `FP_IO_HLENGTH` are now both optional PDK variables
     * The values are now used properly instead of a taking the maximum of both for both kinds of pins
     * For PDKs that do not specify them, the script calculates default values based on the layers' rules