### PR TITLE
Fix Clock Propagation

### DIFF
--- a/openlane/scripts/openroad/sta/corner.tcl
+++ b/openlane/scripts/openroad/sta/corner.tcl
@@ -44,7 +44,9 @@ if { ![info exists ::env(_OPENSTA)] || !$::env(_OPENSTA) } {
 }
 read_spefs
 
-set_propagated_clock [all_clocks]
+if { $::env(STEP_ID) != "OpenROAD.STAPrePNR"} {
+    set_propagated_clock [all_clocks]
+}
 
 set corner [lindex [sta::corners] 0]
 sta::set_cmd_corner $corner

--- a/openlane/steps/tclstep.py
+++ b/openlane/steps/tclstep.py
@@ -136,6 +136,7 @@ class TclStep(Step):
         """
         env = env.copy()
 
+        env["STEP_ID"] = self.get_implementation_id()
         env["SCRIPTS_DIR"] = os.path.abspath(get_script_dir())
         env["STEP_DIR"] = os.path.abspath(self.step_dir)
 


### PR DESCRIPTION
* `OpenROAD.STAPrePNR`
  * Unset clock propagation for this step (misleading as the clock should be ideal before CTS)