### PR TITLE
hotfix: OpenROAD alert crashes

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,16 @@
 ## Documentation
 -->
 
+# 2.0.1
+
+## Steps
+
+* `OpenROAD.*`
+ * Fixed alert about unmatched regexes in `PDN_MACRO_CONNECTIONS` not being
+   properly marked as an `[ERROR]`.
+ * Fixed crash when steps that generate OpenROAD alerts that are suppressed by
+   the flow experience a non-zero exit.  
+
 # 2.0.0
 
 ## Docs

--- a/openlane/__version__.py
+++ b/openlane/__version__.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-__version__ = "2.0.0"
+__version__ = "2.0.1"
 
 if __name__ == "__main__":
     print(__version__, end="")

--- a/openlane/scripts/openroad/common/set_global_connections.tcl
+++ b/openlane/scripts/openroad/common/set_global_connections.tcl
@@ -56,7 +56,7 @@ proc set_global_connections {} {
                 }
             }
             if { $matched != 1 } {
-                puts "No regex match found for $instance_name defined in PDN_MACRO_CONNECTIONS"
+                puts "\[ERROR] No match found for regular expression '$instance_name' defined in PDN_MACRO_CONNECTIONS."
                 exit 1
             }
 

--- a/openlane/steps/openroad.py
+++ b/openlane/steps/openroad.py
@@ -221,13 +221,13 @@ class OpenROADStep(TclStep):
     def get_script_path(self) -> str:
         pass
 
-    def on_alert(self, alert: OpenROADAlert):
+    def on_alert(self, alert: OpenROADAlert) -> OpenROADAlert:
         if alert.code in [
             "ORD-0039",  # .openroad ignored with -python
             "ODB-0220",  # lef parsing/NOWIREEXTENSIONATPIN statement is obsolete in version 5.6 or later.
             "STA-0122",  # table template \w+ not found
         ]:
-            return
+            return alert
         if alert.cls == "error":
             self.err(str(alert))
         elif alert.cls == "warning":


### PR DESCRIPTION
## Steps

* `OpenROAD.*`
   * Fixed alert about unmatched regexes in `PDN_MACRO_CONNECTIONS` not being
   properly marked as an `[ERROR]`.
   * Fixed crash when steps that generate OpenROAD alerts that are suppressed by
   the flow experience a non-zero exit.  