### PR TITLE
hotfix: flatten while generating JSON headers

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -16,6 +16,11 @@
 # 2.0.4
 
 ## Steps
+* `Odb.SetPowerConnections`
+  * Fixed bug where instances with special characters in their name and power
+    pins are not equal to those of the SCL would not get connected.
+  * Added assertion that exactly one pin is connected for every operation.
+  
 * `Yosys.GenerateJSONHeader`
   * Netlist is now flattened so `Odb.SetPowerConnections` can properly set pins
     for nested macros with power pin names not equal to those of the SCL.

--- a/Changelog.md
+++ b/Changelog.md
@@ -13,6 +13,12 @@
 ## API Breaks
 ## Documentation
 -->
+# 2.0.4
+
+## Steps
+* `Yosys.GenerateJSONHeader`
+  * Netlist is now flattened so `Odb.SetPowerConnections` can properly set pins
+    for nested macros with power pin names not equal to those of the SCL.
 
 # 2.0.3
 

--- a/openlane/__version__.py
+++ b/openlane/__version__.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-__version__ = "2.0.3"
+__version__ = "2.0.4"
 
 if __name__ == "__main__":
     print(__version__, end="")

--- a/openlane/scripts/odbpy/power_utils.py
+++ b/openlane/scripts/odbpy/power_utils.py
@@ -226,8 +226,16 @@ def set_power_connections(input_json, reader: OdbReader):
             region = design.getBlock().findRegion(region)
             if region is None:
                 utl.error(utl.PDN, 1504, f"Region {region} not defined")
-
-        design.getBlock().addGlobalConnect(region, inst_pattern, pin_pattern, net, True)
+        connected_items = design.getBlock().addGlobalConnect(
+            region, inst_pattern, pin_pattern, net, True
+        )
+        print(f"Made {connected_items} connections.")
+        assert (
+            connected_items != 0
+        ), f"Global connect failed to make any connections for '{inst_pattern}/{pin_pattern}' to {net_name}"
+        assert (
+            connected_items == 1
+        ), f"Global connect somehow made multiple connections for '{inst_pattern}/{pin_pattern}' to {net_name} -- please report this as a bug"
 
     design_str = open(input_json).read()
     design_dict = json.loads(design_str)
@@ -243,7 +251,7 @@ def set_power_connections(input_json, reader: OdbReader):
             print(f"Connecting power net {net_name} to {instance.name}/{pin}…")
             add_global_connection(
                 design=chip,
-                inst_pattern=re.escape(instance.name),
+                inst_pattern=re.escape(reader.escape_verilog_name(instance.name)),
                 net_name=net_name,
                 pin_pattern=pin,
                 power=True,
@@ -253,7 +261,7 @@ def set_power_connections(input_json, reader: OdbReader):
             print(f"Connecting ground net {net_name} to {instance.name}/{pin}…")
             add_global_connection(
                 design=chip,
-                inst_pattern=re.escape(instance.name),
+                inst_pattern=re.escape(reader.escape_verilog_name(instance.name)),
                 net_name=net_name,
                 pin_pattern=pin,
                 ground=True,

--- a/openlane/scripts/yosys/json_header.tcl
+++ b/openlane/scripts/yosys/json_header.tcl
@@ -20,4 +20,6 @@ yosys_ol::read_verilog_files $::env(DESIGN_NAME)
 hierarchy -check -top $::env(DESIGN_NAME) -nokeep_prints -nokeep_asserts
 yosys rename -top $::env(DESIGN_NAME)
 yosys proc
+flatten
+opt_clean -purge
 json -o $::env(SAVE_JSON_HEADER)


### PR DESCRIPTION
## Steps
* `Odb.SetPowerConnections`
  * Fixed bug where instances with special characters in their name and power
    pins are not equal to those of the SCL would not get connected.
  * Added assertion that exactly one pin is connected for every operation.

* `Yosys.GenerateJSONHeader`
  * Netlist is now flattened so `Odb.SetPowerConnections` can properly set pins
    for nested macros with power pin names not equal to those of the SCL.

## Testing

* `test/designs/dual_spm`
  * SPM macro now hardened with pin names `power`, `ground` (as to not match the standard cell pin names)
  * Dual SPM now nests the macros in a thin wrapper to test that the SPM macro will get its power pins connected properly.

---

Depends on https://github.com/efabless/openlane2-ci-designs/pull/27