### PR TITLE
Ignore undriven checks when running `SYNTH_ELABORATE_ONLY` (#461)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -77,6 +77,7 @@
         sphinx-tippy = callPythonPackage ./nix/sphinx-tippy.nix {};
         sphinx-subfigure = callPythonPackage ./nix/sphinx-subfigure.nix {};
         tclFull = callPackage ./nix/tclFull.nix {};
+        tk-x11 = callPackage ./nix/tk-x11.nix {};
         verilator = callPackage ./nix/verilator.nix {};
         volare = callPackage ./nix/volare.nix {};
         yosys-abc = callPackage ./nix/yosys-abc.nix {};

--- a/nix/magic.nix
+++ b/nix/magic.nix
@@ -37,7 +37,7 @@
   ncurses,
   tcl,
   tcsh,
-  tk,
+  tk-x11,
   cairo,
   python3,
   gnused,
@@ -61,13 +61,13 @@ clangStdenv.mkDerivation rec {
     ncurses
     tcl
     tcsh
-    tk
+    tk-x11
     cairo
   ];
 
   configureFlags = [
     "--with-tcl=${tcl}"
-    "--with-tk=${tk}"
+    "--with-tk=${tk-x11}"
     "--disable-werror"
   ];
 

--- a/nix/tk-x11.nix
+++ b/nix/tk-x11.nix
@@ -1,0 +1,39 @@
+# Copyright 2024 Efabless Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This is a modification of TK that explicitly uses X11 regardless of platform.
+#
+# This is important for some utilities such as Xschem which expect the X11
+# version of Tk even on macOS.
+{
+  xorg,
+  tk,
+}:
+(tk.override {
+  enableAqua = false;
+})
+.overrideAttrs (self: super: {
+  configureFlags =
+    super.configureFlags
+    ++ [
+      "--with-x"
+      "--x-includes=${xorg.libX11}/include"
+      "--x-libraries=${xorg.libX11}/lib"
+    ];
+
+  propagatedBuildInputs =
+    super.propagatedBuildInputs
+    ++ [
+      xorg.libX11
+    ];
+})

--- a/openlane/flows/misc.py
+++ b/openlane/flows/misc.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 from .flow import Flow
 from .sequential import SequentialFlow
-from ..steps import KLayout, OpenROAD
+from ..steps import KLayout, OpenROAD, Magic
 
 
 @Flow.factory.register()
@@ -51,3 +51,21 @@ class OpenInOpenROAD(SequentialFlow):
     name = "Opening in OpenROAD"
 
     Steps = [OpenROAD.OpenGUI]
+
+
+@Flow.factory.register()
+class OpenInMagic(SequentialFlow):
+    """
+    This 'flow' actually just has one step that opens the GDS or DEF from
+    the initial state object in Magic.
+
+    Intended for use with run tags that have already been run with
+    another flow, i.e. ::
+
+      openlane [...]
+      openlane --last-run --flow OpenInMagic [...]
+    """
+
+    name = "Opening in Magic"
+
+    Steps = [Magic.OpenGUI]

--- a/openlane/scripts/klayout/open_design.py
+++ b/openlane/scripts/klayout/open_design.py
@@ -70,4 +70,4 @@ def open_design(input_lefs: Tuple[str, ...], lyt: str, lyp: str, lym: str, input
 
 
 if __name__ == "__main__":
-    open_design(shlex.split(os.getenv("KLAYOUT_ARGV")))
+    open_design(shlex.split(os.environ["KLAYOUT_ARGV"]))

--- a/openlane/scripts/magic/open.tcl
+++ b/openlane/scripts/magic/open.tcl
@@ -1,0 +1,28 @@
+# Copyright 2020 Efabless Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+source $::env(_TCL_ENV_IN)
+
+if { $::env(MAGIC_PRIORITIZE_GDS) && [info exists ::env(CURRENT_GDS)] } {
+    gds read $::env(CURRENT_GDS)
+} else {
+    source $::env(SCRIPTS_DIR)/magic/common/read.tcl
+    read_tech_lef
+    read_pdk_lef
+    read_macro_lef
+    read_def
+}
+
+set cell_name $::env(DESIGN_NAME)
+load $cell_name
+select top cell


### PR DESCRIPTION
## Steps 
* `Yosys.*Synthesis`
* Syntheses with `SYNTH_ELABORATE_ONLY` no longer report undriven nets
as a check error (frequently for some top-level integrations, output
pins are left undriven entirely to save space.)

---
Resolves #387 
Depends on efabless/openlane2-ci-designs#28