### PR TITLE
Fix crash if /etc/os-release has comment lines

### DIFF
--- a/openlane/env_info.py
+++ b/openlane/env_info.py
@@ -246,6 +246,8 @@ class OSInfo(StringRepresentable):
                 for line in os_release.split("\n"):
                     if line.strip() == "":
                         continue
+                    if line.strip().startswith("#"):
+                        continue
                     key, value = line.split("=")
                     value = value.strip('"')
 


### PR DESCRIPTION
Running `python -m openlane --dockerized` will crash if /etc/os-release or /etc/lsb-release has a non-empty line without `=`. These files can have comment lines (without `=`), and in some Linux distributions they indeed do.