### PR TITLE
hotfix: Restructure `power_utils.py` for better error messages

### DIFF
--- a/openlane/scripts/odbpy/power_utils.py
+++ b/openlane/scripts/odbpy/power_utils.py
@@ -133,6 +133,9 @@ class Design(object):
         cells = self.yosys_design_object["cells"]
         for cell_name in cells.keys():
             module = cells[cell_name]["type"]
+            if module.startswith("$"):
+                # yosys primitive
+                continue
             power_pins = self.extract_power_pins(cell_name)
             ground_pins = self.extract_ground_pins(cell_name)
             instances.append(

--- a/openlane/scripts/odbpy/power_utils.py
+++ b/openlane/scripts/odbpy/power_utils.py
@@ -12,46 +12,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-# Some code adapted from OpenROAD
-#
-# BSD 3-Clause License
-#
-# Copyright (c) 2022, The Regents of the University of California
-# All rights reserved.
-#
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions are met:
-#
-# * Redistributions of source code must retain the above copyright notice, this
-#   list of conditions and the following disclaimer.
-#
-# * Redistributions in binary form must reproduce the above copyright notice,
-#   this list of conditions and the following disclaimer in the documentation
-#   and/or other materials provided with the distribution.
-#
-# * Neither the name of the copyright holder nor the names of its
-#   contributors may be used to endorse or promote products derived from
-#   this software without specific prior written permission.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-# POSSIBILITY OF SUCH DAMAGE.
 import odb
 import utl
 
 import re
 import json
-from typing import List, Optional
-from collections import namedtuple
+import functools
+from dataclasses import dataclass
+from typing import Dict, List, Optional
 
 from reader import OdbReader, click_odb, click
 
@@ -61,116 +29,114 @@ def cli():
     pass
 
 
-@click.command()
-@click.option(
-    "--input-json",
-    type=click.Path(
-        exists=True,
-        file_okay=True,
-        dir_okay=False,
-        readable=True,
-    ),
-    required=True,
-)
-@click_odb
-def set_power_connections(input_json, reader: OdbReader):
-    Instance = namedtuple(
-        "Instance",
-        ["name", "module", "power_connections", "ground_connections"],
-    )
+class Design(object):
+    @dataclass
+    class Instance:
+        name: str
+        module: str
+        power_connections: Dict[str, str]
+        ground_connections: Dict[str, str]
 
-    def is_power(db: odb.dbDatabase, module_name: str, pin_name: str) -> bool:
-        master = db.findMaster(module_name)
-        if master is None:
-            return False
+    def __init__(self, reader: OdbReader, yosys_dict: dict) -> None:
+        self.reader = reader
+        self.design_name = reader.block.getName()
+        self.yosys_dict = yosys_dict
+        self.yosys_design_object = yosys_dict["modules"][self.design_name]
 
-        pin = next(pin for pin in master.getMTerms() if pin.getName() == pin_name)
-        return pin.getSigType() == "POWER"
-
-    def is_ground(db: odb.dbDatabase, module_name: str, pin_name: str) -> bool:
-        master = db.findMaster(module_name)
-        if master is None:
-            return False
-
-        pin = next(
-            pin
-            for pin in db.findMaster(module_name).getMTerms()
-            if pin.getName() == pin_name
+        self.pins_by_module_name: Dict[str, Dict[str, odb.dbMTerm]] = {}
+        self.net_name_by_bit: Dict[int, str] = functools.reduce(
+            lambda a, b: {**a, **{bit: b[0] for bit in b[1]["bits"]}},
+            self.yosys_design_object["netnames"].items(),
+            {},
         )
-        return pin.getSigType() == "GROUND"
 
-    def is_bus(pin_connections: List) -> bool:
+    def get_pins(self, module_name: str) -> Dict[str, odb.dbMTerm]:
+        if module_name not in self.pins_by_module_name:
+            master = self.reader.db.findMaster(module_name)
+            if master is None:
+                print(
+                    f"[ERROR] No LEF view for {module_name} was found in the database even though it is declared in the Verilog."
+                )
+                exit(-1)
+            pins = {pin.getName(): pin for pin in master.getMTerms()}
+            self.pins_by_module_name[module_name] = pins
+        return self.pins_by_module_name[module_name]
+
+    def is_power(self, module_name: str, pin_name: str) -> bool:
+        module_pins = self.get_pins(module_name)
+        if pin_name not in module_pins:
+            print(
+                f"[ERROR] No pin {pin_name} found in the module {module_name}'s LEF view: the LEF and Verilog views of the module may be mismatched."
+            )
+            exit(-1)
+
+        return module_pins[pin_name].getSigType() == "POWER"
+
+    def is_ground(self, module_name: str, pin_name: str) -> bool:
+        module_pins = self.get_pins(module_name)
+        if pin_name not in module_pins:
+            print(
+                f"[ERROR] No pin {pin_name} found in the module {module_name}'s LEF view: the LEF and Verilog views of the module may be mismatched."
+            )
+            exit(-1)
+
+        return module_pins[pin_name].getSigType() == "GROUND"
+
+    def is_bus(self, pin_connections: List) -> bool:
         return len(pin_connections) > 1
 
-    def extract_net_name(
-        design_dict: dict, design_name: str, connection_bit: List
-    ) -> str:
-        assert len(connection_bit) == 1
-        nets = design_dict["modules"][design_name]["netnames"]
-        net = next(
-            wire_name
-            for wire_name in nets.keys()
-            if nets[wire_name]["bits"] == connection_bit
-        )
-        return net
-
-    def extract_power_pins(
-        db: odb.dbDatabase, design_dict: dict, design_name: str, cell_name: str
-    ) -> dict:
-        cells = design_dict["modules"][design_name]["cells"]
+    def extract_power_pins(self, cell_name: str) -> dict:
+        cells = self.yosys_design_object["cells"]
         module = cells[cell_name]["type"]
         non_bus_pins = {
             pin_name: cells[cell_name]["connections"][pin_name]
             for pin_name in cells[cell_name]["connections"].keys()
-            if not is_bus(cells[cell_name]["connections"][pin_name])
+            if not self.is_bus(cells[cell_name]["connections"][pin_name])
         }
         power_pins = {
             pin_name: non_bus_pins[pin_name]
             for pin_name in non_bus_pins.keys()
-            if is_power(db, module, pin_name)
+            if self.is_power(module, pin_name)
         }
         for pin_name in power_pins.keys():
-            connection_bit = power_pins[pin_name]
-            net = extract_net_name(design_dict, design_name, connection_bit)
-            power_pins[pin_name] = net
+            connection_bits = power_pins[pin_name]
+            assert len(connection_bits) == 1, "Power connection has more than one net"
+            connection_bit = connection_bits[0]
+            power_pins[pin_name] = self.net_name_by_bit[connection_bit]
 
         return power_pins
 
-    def extract_ground_pins(
-        db: odb.dbDatabase, design_dict: dict, design_name: str, cell_name: str
-    ) -> dict:
-        cells = design_dict["modules"][design_name]["cells"]
+    def extract_ground_pins(self, cell_name: str) -> dict:
+        cells = self.yosys_design_object["cells"]
         module = cells[cell_name]["type"]
+        connections = cells[cell_name]["connections"]
         non_bus_pins = {
-            pin_name: cells[cell_name]["connections"][pin_name]
-            for pin_name in cells[cell_name]["connections"].keys()
-            if not is_bus(cells[cell_name]["connections"][pin_name])
+            pin_name: connections[pin_name]
+            for pin_name in connections.keys()
+            if not self.is_bus(connections[pin_name])
         }
         ground_pins = {
             pin_name: non_bus_pins[pin_name]
             for pin_name in non_bus_pins.keys()
-            if is_ground(db, module, pin_name)
+            if self.is_ground(module, pin_name)
         }
         for pin_name in ground_pins.keys():
-            connection_bit = ground_pins[pin_name]
-            net = extract_net_name(design_dict, design_name, connection_bit)
-            ground_pins[pin_name] = net
+            connection_bits = ground_pins[pin_name]
+            assert len(connection_bits) == 1, "Ground connection has more than one net"
+            connection_bit = connection_bits[0]
+            ground_pins[pin_name] = self.net_name_by_bit[connection_bit]
 
         return ground_pins
 
-    def extract_instances(
-        db: odb.dbDatabase,
-        design_dict: dict,
-        design_name: str,
-    ) -> List[Instance]:
+    def extract_instances(self) -> List["Design.Instance"]:
         instances = []
-        cells = design_dict["modules"][design_name]["cells"]
+        cells = self.yosys_design_object["cells"]
         for cell_name in cells.keys():
             module = cells[cell_name]["type"]
-            power_pins = extract_power_pins(db, design_dict, design_name, cell_name)
-            ground_pins = extract_ground_pins(db, design_dict, design_name, cell_name)
+            power_pins = self.extract_power_pins(cell_name)
+            ground_pins = self.extract_ground_pins(cell_name)
             instances.append(
-                Instance(
+                Design.Instance(
                     name=cell_name,
                     ground_connections=ground_pins,
                     power_connections=power_pins,
@@ -181,8 +147,7 @@ def set_power_connections(input_json, reader: OdbReader):
         return instances
 
     def add_global_connection(
-        design,
-        *,
+        self,
         net_name: str,
         inst_name: str,
         pin_name: str,
@@ -190,6 +155,38 @@ def set_power_connections(input_json, reader: OdbReader):
         ground: bool = False,
         region: Optional[odb.dbRegion] = None,
     ):
+        # Function adapted from OpenROAD
+        #
+        # Copyright (c) 2022, The Regents of the University of California
+        # All rights reserved.
+        #
+        # Redistribution and use in source and binary forms, with or without
+        # modification, are permitted provided that the following conditions are met:
+        #
+        # * Redistributions of source code must retain the above copyright notice, this
+        #   list of conditions and the following disclaimer.
+        #
+        # * Redistributions in binary form must reproduce the above copyright notice,
+        #   this list of conditions and the following disclaimer in the documentation
+        #   and/or other materials provided with the distribution.
+        #
+        # * Neither the name of the copyright holder nor the names of its
+        #   contributors may be used to endorse or promote products derived from
+        #   this software without specific prior written permission.
+        #
+        # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+        # AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+        # IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+        # ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+        # LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+        # CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+        # SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+        # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+        # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+        # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+        # POSSIBILITY OF SUCH DAMAGE.
+
+        design = self.reader.chip
         net = design.getBlock().findNet(net_name)
         if net is None:
             net = odb.dbNet_create(design.getBlock(), net_name)
@@ -209,8 +206,8 @@ def set_power_connections(input_json, reader: OdbReader):
                 utl.error(utl.PDN, 1504, f"Region {region} not defined")
                 exit(-1)
 
-        inst_def_name = reader.escape_verilog_name(inst_name)
-        pin_def_name = reader.escape_verilog_name(pin_name)
+        inst_def_name = self.reader.escape_verilog_name(inst_name)
+        pin_def_name = self.reader.escape_verilog_name(pin_name)
 
         for term in net.getITerms():
             if (
@@ -229,27 +226,41 @@ def set_power_connections(input_json, reader: OdbReader):
         )
         print(f"Made {connected_items} connections.")
 
-        assert (
-            connected_items != 0
-        ), f"Global connect failed to make any connections for '{inst_name}/{pin_name}' to {net_name}"
-        assert (
-            connected_items == 1
-        ), f"Global connect somehow made multiple connections for '{inst_name}/{pin_name}' to {net_name} -- please report this as a bug"
+        if connected_items == 0:
+            print(
+                f"[ERROR] add_global_connections failed to make any connections for '{inst_name}/{pin_name}' to {net_name}."
+            )
+            exit(-1)
+        elif connected_items > 1:
+            print(
+                f"[ERROR] add_global_connections somehow made multiple connections for '{inst_name}/{pin_name}' to {net_name} -- please report this as a bug"
+            )
+            exit(-1)
 
+
+@click.command()
+@click.option(
+    "--input-json",
+    type=click.Path(
+        exists=True,
+        file_okay=True,
+        dir_okay=False,
+        readable=True,
+    ),
+    required=True,
+)
+@click_odb
+def set_power_connections(input_json, reader: OdbReader):
     design_str = open(input_json).read()
-    design_dict = json.loads(design_str)
+    yosys_dict = json.loads(design_str)
 
-    db = reader.db
-    chip = db.getChip()
-    design_name = chip.getBlock().getName()
-
-    macro_instances = extract_instances(db, design_dict, design_name)
+    design = Design(reader, yosys_dict)
+    macro_instances = design.extract_instances()
     for instance in macro_instances:
         for pin in instance.power_connections.keys():
             net_name = instance.power_connections[pin]
             print(f"Connecting power net {net_name} to {instance.name}/{pin}…")
-            add_global_connection(
-                design=chip,
+            design.add_global_connection(
                 inst_name=instance.name,
                 net_name=net_name,
                 pin_name=pin,
@@ -258,8 +269,7 @@ def set_power_connections(input_json, reader: OdbReader):
         for pin in instance.ground_connections.keys():
             net_name = instance.ground_connections[pin]
             print(f"Connecting ground net {net_name} to {instance.name}/{pin}…")
-            add_global_connection(
-                design=chip,
+            design.add_global_connection(
                 inst_name=instance.name,
                 net_name=net_name,
                 pin_name=pin,


### PR DESCRIPTION
* `Odb.SetPowerConnections`
  * **Internal**: Restructure `power_utils.py` to provide better error messages and use dictionaries instead of oddball iterator-based filtering

---

See #470 