### PR TITLE
hotfix: fix diodes on output ports not working

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -13,6 +13,14 @@
 ## API Breaks
 ## Documentation
 -->
+# 2.0.8
+
+## Steps
+
+* `Odb.DiodePortInsertion`, `Odb.DiodesOnPorts`
+  * Fixed bug where diodes were never inserted on outputs, and added unit tests
+    to that effect.
+
 # 2.0.7
 
 ## Misc Enhancements/Bugfixes

--- a/openlane/__version__.py
+++ b/openlane/__version__.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-__version__ = "2.0.7"
+__version__ = "2.0.8"
 
 if __name__ == "__main__":
     print(__version__, end="")

--- a/openlane/scripts/odbpy/diodes.py
+++ b/openlane/scripts/odbpy/diodes.py
@@ -88,7 +88,7 @@ class DiodeInserter:
         # Nothing found
         return None
 
-    def net_from_pin(self, net, io_types=None):
+    def should_protect_io_net(self, net, io_types=None):
         for bt in net.getBTerms():
             if (io_types is None) or (bt.getIoType() in io_types):
                 return True
@@ -267,8 +267,8 @@ class DiodeInserter:
 
             # Is this an IO we need to protect
             io_protect = None
-            if self.net_from_pin(net, io_types=["INPUT", "OUTPUT"]):
-                io_protect = self.net_from_pin(net, io_types=self.port_protect)
+            if self.should_protect_io_net(net, io_types=["INPUT", "OUTPUT"]):
+                io_protect = self.should_protect_io_net(net, io_types=self.port_protect)
                 if io_protect:
                     self.debug(
                         f"[d] Forcing protection diode on I/O net {net.getConstName():s}"
@@ -291,8 +291,12 @@ class DiodeInserter:
             )
 
             # Scan all internal terminals
-            for iterm in net.getITerms():
-                if iterm.isInputSignal():
+            if len(net.getITerms()) == 0:
+                self.debug(
+                    f"[d] Skipping net {net.getConstName():s}: not connected to any instances"
+                )
+            else:
+                for iterm in net.getITerms():
                     self.insert_diode(net, iterm, src_pos)
 
 


### PR DESCRIPTION
* `Odb.DiodePortInsertion`, `Odb.DiodesOnPorts`
  * Fixed bug where diodes were never inserted on outputs, and added unit tests to that effect.

---

Depends on https://github.com/efabless/openlane2-step-unit-tests/pull/33