### PR TITLE
Update `ioplace_parser` to fix regression

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -13,6 +13,18 @@
 ## API Breaks
 ## Documentation
 -->
+# 2.0.9
+
+## CLI
+
+* Fixed `--ef-save-views-to` saving to `signoff/<design>/openlane` instead of
+  `signoff/<design>/openlane-signoff` (which makes less sense but is the
+  established convention at Efabless.)
+
+## Tool Updates
+* Updated `ioplace_parser` to `0.2.0`
+  * Fixes regressions in pin regular expression parsing.
+
 # 2.0.8
 
 ## Steps

--- a/Changelog.md
+++ b/Changelog.md
@@ -20,6 +20,11 @@
 * Fixed `--ef-save-views-to` saving to `signoff/<design>/openlane` instead of
   `signoff/<design>/openlane-signoff` (which makes less sense but is the
   established convention at Efabless.)
+  
+## Steps
+
+* `OpenROAD.GeneratePDN`
+  * Restored compatibility with some ancient OpenLane PDN config files.
 
 ## Tool Updates
 * Updated `ioplace_parser` to `0.2.0`

--- a/Changelog.md
+++ b/Changelog.md
@@ -23,6 +23,10 @@
   
 ## Steps
 
+* `OpenROAD.*`
+  * Fixed environment contamination with deprecated variables that may be used
+    by user-supplied PDN or SDC files.
+
 * `OpenROAD.GeneratePDN`
   * Restored compatibility with some ancient OpenLane PDN config files.
 

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1713262631,
-        "narHash": "sha256-0Lt3DVImH3TpwUh7sDW/6Cxsrmo5DDG+SCuirBFquXs=",
+        "lastModified": 1717940678,
+        "narHash": "sha256-GxEmeujXSw8ey3KXhQpYHKlZu/wJmeX4eS1UO8nLQ44=",
         "owner": "efabless",
         "repo": "ioplace_parser",
-        "rev": "f1c163e8184fbce2676a19a1d28c3e6c0b5ddaf2",
+        "rev": "4849956df82b88f9290dc723b6da0ce91838a8e1",
         "type": "github"
       },
       "original": {

--- a/openlane/__version__.py
+++ b/openlane/__version__.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-__version__ = "2.0.8"
+__version__ = "2.0.9"
 
 if __name__ == "__main__":
     print(__version__, end="")

--- a/openlane/flows/flow.py
+++ b/openlane/flows/flow.py
@@ -854,7 +854,7 @@ class Flow(ABC):
                     )
 
         signoff_folder = os.path.join(
-            path, "signoff", self.config["DESIGN_NAME"], "openlane"
+            path, "signoff", self.config["DESIGN_NAME"], "openlane-signoff"
         )
         mkdirp(signoff_folder)
 

--- a/openlane/scripts/openroad/common/io.tcl
+++ b/openlane/scripts/openroad/common/io.tcl
@@ -35,7 +35,8 @@ proc read_current_sdc {} {
         return
     }
 
-    # Deprecated Variables That May Still Be Used By User Files
+    # Compatibility Layer for Deprecated Variables That May Still Be Used By
+    # User Files
     set ::env(IO_PCT) [expr $::env(IO_DELAY_CONSTRAINT) / 100]
     set ::env(SYNTH_TIMING_DERATE) [expr $::env(TIME_DERATING_CONSTRAINT) / 100]
     set ::env(SYNTH_MAX_FANOUT) $::env(MAX_FANOUT_CONSTRAINT)
@@ -46,6 +47,7 @@ proc read_current_sdc {} {
         set ::env(SYNTH_MAX_TRAN) $::env(MAX_TRANSITION_CONSTRAINT)
     }
     if { [env_var_used $::env(_SDC_IN) SYNTH_DRIVING_CELL_PIN] == 1 } {
+        set synth_driving_cell_bk $::env(SYNTH_DRIVING_CELL)
         set ::env(SYNTH_DRIVING_CELL_PIN) [lindex [split $::env(SYNTH_DRIVING_CELL) "/"] 1]
         set ::env(SYNTH_DRIVING_CELL) [lindex [split $::env(SYNTH_DRIVING_CELL) "/"] 0]
     }
@@ -55,10 +57,27 @@ proc read_current_sdc {} {
         puts stderr $errmsg
         exit 1
     }
+
+    # Restore Environment
+    unset ::env(IO_PCT)
+    unset ::env(SYNTH_TIMING_DERATE)
+    unset ::env(SYNTH_MAX_FANOUT)
+    unset ::env(SYNTH_CLOCK_UNCERTAINTY)
+    unset ::env(SYNTH_CLOCK_TRANSITION)
+    unset ::env(SYNTH_CAP_LOAD)
+    if { [info exists ::env(SYNTH_MAX_TRAN)] } {
+        unset ::env(SYNTH_MAX_TRAN)
+    }
+    if { [info exists ::env(SYNTH_DRIVING_CELL_PIN)] } {
+        unset ::env(SYNTH_DRIVING_CELL_PIN)
+        set ::env(SYNTH_DRIVING_CELL) $synth_driving_cell_bk
+    }
 }
 
 proc read_pdn_cfg {} {
-    # Deprecated Variables That May Still Be Used By User Files
+
+    # Compatibility Layer for Deprecated Variables That May Still Be Used By
+    # User Files
     set ::env(DESIGN_IS_CORE) $::env(FP_PDN_MULTILAYER)
     set ::env(FP_PDN_ENABLE_MACROS_GRID) $::env(PDN_CONNECT_MACROS_TO_GRID)
     set ::env(FP_PDN_RAILS_LAYER) $::env(FP_PDN_RAIL_LAYER)
@@ -69,6 +88,13 @@ proc read_pdn_cfg {} {
         puts stderr $errmsg
         exit 1
     }
+
+    # Restore Environment
+    unset ::env(DESIGN_IS_CORE)
+    unset ::env(FP_PDN_ENABLE_MACROS_GRID)
+    unset ::env(FP_PDN_RAILS_LAYER)
+    unset ::env(FP_PDN_UPPER_LAYER)
+    unset ::env(FP_PDN_LOWER_LAYER)
 }
 
 

--- a/openlane/scripts/openroad/common/io.tcl
+++ b/openlane/scripts/openroad/common/io.tcl
@@ -59,6 +59,7 @@ proc read_current_sdc {} {
 
 proc read_pdn_cfg {} {
     # Deprecated Variables That May Still Be Used By User Files
+    set ::env(DESIGN_IS_CORE) $::env(FP_PDN_MULTILAYER)
     set ::env(FP_PDN_ENABLE_MACROS_GRID) $::env(PDN_CONNECT_MACROS_TO_GRID)
     set ::env(FP_PDN_RAILS_LAYER) $::env(FP_PDN_RAIL_LAYER)
     set ::env(FP_PDN_UPPER_LAYER) $::env(FP_PDN_HORIZONTAL_LAYER)

--- a/openlane/scripts/openroad/common/io.tcl
+++ b/openlane/scripts/openroad/common/io.tcl
@@ -34,6 +34,8 @@ proc read_current_sdc {} {
         puts "\[INFO] _SDC_IN not found. Not reading an SDC file."
         return
     }
+
+    # Deprecated Variables That May Still Be Used By User Files
     set ::env(IO_PCT) [expr $::env(IO_DELAY_CONSTRAINT) / 100]
     set ::env(SYNTH_TIMING_DERATE) [expr $::env(TIME_DERATING_CONSTRAINT) / 100]
     set ::env(SYNTH_MAX_FANOUT) $::env(MAX_FANOUT_CONSTRAINT)
@@ -43,7 +45,6 @@ proc read_current_sdc {} {
     if { [info exists ::env(MAX_TRANSITION_CONSTRAINT)] } {
         set ::env(SYNTH_MAX_TRAN) $::env(MAX_TRANSITION_CONSTRAINT)
     }
-
     if { [env_var_used $::env(_SDC_IN) SYNTH_DRIVING_CELL_PIN] == 1 } {
         set ::env(SYNTH_DRIVING_CELL_PIN) [lindex [split $::env(SYNTH_DRIVING_CELL) "/"] 1]
         set ::env(SYNTH_DRIVING_CELL) [lindex [split $::env(SYNTH_DRIVING_CELL) "/"] 0]
@@ -51,6 +52,19 @@ proc read_current_sdc {} {
 
     puts "Reading design constraints file at '$::env(_SDC_IN)'…"
     if {[catch {read_sdc $::env(_SDC_IN)} errmsg]} {
+        puts stderr $errmsg
+        exit 1
+    }
+}
+
+proc read_pdn_cfg {} {
+    # Deprecated Variables That May Still Be Used By User Files
+    set ::env(FP_PDN_ENABLE_MACROS_GRID) $::env(PDN_CONNECT_MACROS_TO_GRID)
+    set ::env(FP_PDN_RAILS_LAYER) $::env(FP_PDN_RAIL_LAYER)
+    set ::env(FP_PDN_UPPER_LAYER) $::env(FP_PDN_HORIZONTAL_LAYER)
+    set ::env(FP_PDN_LOWER_LAYER) $::env(FP_PDN_VERTICAL_LAYER)
+
+    if {[catch {source $::env(FP_PDN_CFG)} errmsg]} {
         puts stderr $errmsg
         exit 1
     }

--- a/openlane/scripts/openroad/pdn.tcl
+++ b/openlane/scripts/openroad/pdn.tcl
@@ -18,10 +18,8 @@ read_current_odb
 source $::env(SCRIPTS_DIR)/openroad/common/set_power_nets.tcl
 
 # load the grid definitions
-if {[catch {source $::env(FP_PDN_CFG)} errmsg]} {
-    puts stderr $errmsg
-    exit 1
-}
+read_pdn_cfg
+
 set arg_list [list]
 if { $::env(FP_PDN_SKIPTRIM) } {
     lappend arg_list -skip_trim

--- a/openlane/steps/openroad.py
+++ b/openlane/steps/openroad.py
@@ -1129,7 +1129,6 @@ class GeneratePDN(OpenROADStep):
                 get_script_dir(), "openroad", "common", "pdn_cfg.tcl"
             )
             info(f"'FP_PDN_CFG' not explicitly set, setting it to {env['FP_PDN_CFG']}…")
-        env["DESIGN_IS_CORE"] = "1" if self.config["FP_PDN_MULTILAYER"] else "0"
         views_updates, metrics_updates = super().run(state_in, env=env, **kwargs)
 
         error_reports = glob(os.path.join(self.step_dir, "*-grid-errors.rpt"))

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,5 @@ immutabledict>=2,<3
 libparse>=0.3.1,<1
 psutil>=5.9.0
 httpx>=0.22.0, <0.28
-ioplace_parser~=0.1.0
+ioplace_parser~=0.2.0
 klayout>=0.28.17.post1,<0.29.0


### PR DESCRIPTION
## CLI

* Fixed `--ef-save-views-to` saving to `signoff/<design>/openlane` instead of
  `signoff/<design>/openlane-signoff` (which makes less sense but is the
  established convention at Efabless.)
  
## Steps

* `OpenROAD.*`
  * Fixed environment contamination with deprecated variables that may be used
    by user-supplied PDN or SDC files.

* `OpenROAD.GeneratePDN`
  * Restored compatibility with some ancient OpenLane PDN config files.


## Tool Updates
* Updated `ioplace_parser` to `0.2.0`
  * Fixes regressions in pin regular expression parsing.