### PR TITLE
Rename top level after application of parameters early enough.  Fixes DFFRAM with OpenLane2.0.8

### DIFF
--- a/openlane/scripts/yosys/synthesize.tcl
+++ b/openlane/scripts/yosys/synthesize.tcl
@@ -66,10 +66,10 @@ if { [info exists ::env(VERILOG_FILES) ]} {
 }
 
 hierarchy -check -top $::env(DESIGN_NAME) -nokeep_prints -nokeep_asserts
+yosys rename -top $::env(DESIGN_NAME)
 select -module $::env(DESIGN_NAME)
 catch {show -format dot -prefix $::env(STEP_DIR)/hierarchy}
 select -clear
-yosys rename -top $::env(DESIGN_NAME)
 
 if { $::env(SYNTH_ELABORATE_ONLY) } {
     yosys_ol::ol_proc $report_dir


### PR DESCRIPTION
Moves the rename of top module to before selecting it.  This fixes a problem with mainline OpenLane2 and e.g. DFFRAM where needed modules are optimised away and then synthesis fails:

```
...
5.23. Analyzing design hierarchy..
Top module:  $paramod\RAM128\WSIZE=32'00000000000000000000000000000100
...
Removed 30 unused modules.
ERROR: No such module: RAM128
```

I believe this was introduced around 2.0.0b17, during the refactoring of the synthesis script.

It needs to be run on a multiple designs to prove that the new ordering doesn't negatively affect something unexpected.