### PR TITLE
Relax Rich Range

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -13,6 +13,13 @@
 ## API Breaks
 ## Documentation
 -->
+# 2.0.10
+
+## Tool Updates
+* Relaxed `rich` version range to allow Rich 13.
+  * Matches Volare's version range and allows CACE and OpenLane 2 to be
+    installed in the same Python environment.
+
 # 2.0.9
 
 ## CLI

--- a/openlane/__version__.py
+++ b/openlane/__version__.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-__version__ = "2.0.9"
+__version__ = "2.0.10"
 
 if __name__ == "__main__":
     print(__version__, end="")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 click>=8,<9
 cloup>=1.0.1,<2
 pyyaml>=5,<7
-rich>=12,<13
+rich>=12,<14
 volare>=0.16.0
 lxml>=4.9.0
 deprecated>=1.2.10,<2


### PR DESCRIPTION
## Tool Updates
* Relaxed `rich` version range to allow Rich 13.
  * Matches Volare's version range and allows CACE and OpenLane 2 to be installed in the same Python environment.