### PR TITLE
Fix Deadlock

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -13,6 +13,13 @@
 ## API Breaks
 ## Documentation
 -->
+# 2.0.11
+
+## Misc Enhancements/Bugfixes
+
+* Fixed a deadlock in some situations because of `OpenROAD.STAPrePNR` using the
+  global thread-pool for OpenLane, which may be used to run the step itself.
+
 # 2.0.10
 
 ## Tool Updates

--- a/openlane/__version__.py
+++ b/openlane/__version__.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-__version__ = "2.0.10"
+__version__ = "2.0.11"
 
 if __name__ == "__main__":
     print(__version__, end="")

--- a/openlane/common/tpe.py
+++ b/openlane/common/tpe.py
@@ -23,6 +23,9 @@ def set_tpe(tpe: ThreadPoolExecutor):
     Allows replacing OpenLane's global ``ThreadPoolExecutor`` with a customized
     one.
 
+    It will be used inside steps, so use different TPEs inside steps to avoid
+    a deadlock.
+
     :param tpe: The replacement ThreadPoolExecutor
     """
     global TPE
@@ -31,7 +34,8 @@ def set_tpe(tpe: ThreadPoolExecutor):
 
 def get_tpe() -> ThreadPoolExecutor:
     """
-    :returns: OpenLane's global ``ThreadPoolExecutor``
+    :returns: OpenLane's global ``ThreadPoolExecutor``. This is used to run
+        steps, so do not use them inside steps to avoid a deadlock.
     """
     global TPE
     return TPE


### PR DESCRIPTION
## Misc Enhancements/Bugfixes

* Fixed a deadlock in some situations because of `OpenROAD.STAPrePNR` using the
  global thread-pool for OpenLane, which may be used to run the step itself.


---

Resolves #501 