### PR TITLE
Added soft placement obstructions to Floorplanning

### DIFF
--- a/openlane/config/variable.py
+++ b/openlane/config/variable.py
@@ -436,6 +436,8 @@ class Variable:
                     raw = raw.split(";")
                 else:
                     raw = raw.split()
+                if raw[-1] == "":
+                    raw.pop()  # Trailing commas
             else:
                 raise ValueError(
                     f"List provided for variable '{key_path}' is invalid: {value}"

--- a/openlane/scripts/openroad/floorplan.tcl
+++ b/openlane/scripts/openroad/floorplan.tcl
@@ -97,7 +97,7 @@ if { [info exists ::env(FP_OBSTRUCTIONS)] } {
         set urx [expr int([expr [lindex $obstruction 2] * $::dbu])]
         set ury [expr int([expr [lindex $obstruction 3] * $::dbu])]
         odb::dbBlockage_create [ord::get_db_block] $llx $lly $urx $ury
-        puts "\[INFO] Created obstruction at $::env(FP_OBSTRUCTIONS) (µm)"
+        puts "\[INFO] Created floorplan obstruction at $obstruction (µm)"
     }
 }
 
@@ -105,6 +105,18 @@ initialize_floorplan {*}$arg_list
 
 insert_tiecells $::env(SYNTH_TIELO_CELL) -prefix "TIE_ZERO_"
 insert_tiecells $::env(SYNTH_TIEHI_CELL) -prefix "TIE_ONE_"
+
+if { [info exists ::env(PL_OBSTRUCTIONS)] } {
+    foreach obstruction $::env(PL_OBSTRUCTIONS) {
+        set llx [expr int([expr [lindex $obstruction 0] * $::dbu])]
+        set lly [expr int([expr [lindex $obstruction 1] * $::dbu])]
+        set urx [expr int([expr [lindex $obstruction 2] * $::dbu])]
+        set ury [expr int([expr [lindex $obstruction 3] * $::dbu])]
+        set obstruction_o [odb::dbBlockage_create [ord::get_db_block] $llx $lly $urx $ury]
+        set _ [$obstruction_o setSoft]
+        puts "\[INFO] Created soft placement obstruction at $obstruction (µm)"
+    }
+}
 
 puts "\[INFO] Extracting DIE_AREA and CORE_AREA from the floorplan"
 set ::env(DIE_AREA) [list]

--- a/openlane/scripts/openroad/floorplan.tcl
+++ b/openlane/scripts/openroad/floorplan.tcl
@@ -106,8 +106,8 @@ initialize_floorplan {*}$arg_list
 insert_tiecells $::env(SYNTH_TIELO_CELL) -prefix "TIE_ZERO_"
 insert_tiecells $::env(SYNTH_TIEHI_CELL) -prefix "TIE_ONE_"
 
-if { [info exists ::env(PL_OBSTRUCTIONS)] } {
-    foreach obstruction $::env(PL_OBSTRUCTIONS) {
+if { [info exists ::env(PL_SOFT_OBSTRUCTIONS)] } {
+    foreach obstruction $::env(PL_SOFT_OBSTRUCTIONS) {
         set llx [expr int([expr [lindex $obstruction 0] * $::dbu])]
         set lly [expr int([expr [lindex $obstruction 1] * $::dbu])]
         set urx [expr int([expr [lindex $obstruction 2] * $::dbu])]

--- a/openlane/steps/openroad.py
+++ b/openlane/steps/openroad.py
@@ -903,7 +903,13 @@ class Floorplan(OpenROADStep):
         Variable(
             "FP_OBSTRUCTIONS",
             Optional[List[Tuple[Decimal, Decimal, Decimal, Decimal]]],
-            "Obstructions applied at floorplanning stage. These affect row generation and hence affects cells placement.",
+            "Obstructions applied at floorplanning stage. Placement sites are never generated at these locations, which guarantees that it will remain empty throughout the entire flow.",
+            units="µm",
+        ),
+        Variable(
+            "PL_OBSTRUCTIONS",
+            Optional[List[Tuple[Decimal, Decimal, Decimal, Decimal]]],
+            "Soft placement blockages applied at the floorplanning stage. Areas that are soft-blocked will not be used by the initial placer, however, later phases such as buffer insertion or clock tree synthesis are still allowed to place cells in this area.",
             units="µm",
         ),
         Variable(

--- a/openlane/steps/openroad.py
+++ b/openlane/steps/openroad.py
@@ -907,7 +907,7 @@ class Floorplan(OpenROADStep):
             units="µm",
         ),
         Variable(
-            "PL_OBSTRUCTIONS",
+            "PL_SOFT_OBSTRUCTIONS",
             Optional[List[Tuple[Decimal, Decimal, Decimal, Decimal]]],
             "Soft placement blockages applied at the floorplanning stage. Areas that are soft-blocked will not be used by the initial placer, however, later phases such as buffer insertion or clock tree synthesis are still allowed to place cells in this area.",
             units="µm",


### PR DESCRIPTION
* `OpenROAD.Floorplan`
  * Added soft placement obstructions via new variable `PL_SOFT_OBSTRUCTIONS`.

## Misc. Enhancements/Bugfixes

* `openlane.common.config`
  * Trailing commas are now permitted when converting from a string format (which are necessary because of the ambiguity of lists of lists.)