### PR TITLE
Netlist Assign Statement Checker

### DIFF
--- a/openlane/examples/spm-user_project_wrapper/SPM_example.v
+++ b/openlane/examples/spm-user_project_wrapper/SPM_example.v
@@ -241,8 +241,9 @@ module spm #(parameter bits=32) (
     assign y = y_chain[bits];
 
     wire[bits-1:0] a_flip;
+    genvar i;
     generate 
-        for (genvar i = 0; i < bits; i = i + 1) begin : flip_block
+        for (i = 0; i < bits; i = i + 1) begin : flip_block
             assign a_flip[i] = a[bits - i - 1];
         end 
     endgenerate

--- a/openlane/examples/spm/src/spm.v
+++ b/openlane/examples/spm/src/spm.v
@@ -28,8 +28,9 @@ module spm #(parameter bits=32) (
     assign y = y_chain[bits];
 
     wire[bits-1:0] a_flip;
+    genvar i;
     generate 
-        for (genvar i = 0; i < bits; i = i + 1) begin : flip_block
+        for (i = 0; i < bits; i = i + 1) begin : flip_block
             assign a_flip[i] = a[bits - i - 1];
         end 
     endgenerate

--- a/openlane/flows/classic.py
+++ b/openlane/flows/classic.py
@@ -49,6 +49,7 @@ class Classic(SequentialFlow):
         Yosys.Synthesis,
         Checker.YosysUnmappedCells,
         Checker.YosysSynthChecks,
+        Checker.NetlistAssignStatements,
         OpenROAD.CheckSDCFiles,
         OpenROAD.CheckMacroInstances,
         OpenROAD.STAPrePNR,
@@ -313,14 +314,12 @@ class Classic(SequentialFlow):
 class VHDLClassic(Classic):
     """
     A variant of Classic that accepts VHDL files for Synthesis instead of
-    Verilog files (and disables Verilog linting/equivalence steps.)
+    Verilog files (and removes Verilog linting/equivalence steps.)
     """
 
     Substitutions = {
         "Verilator.Lint": None,
-        "Checker.LintTimingConstructs": None,
-        "Checker.LintErrors": None,
-        "Checker.LintWarnings": None,
+        "Checker.Lint*": None,
         "Yosys.JsonHeader": None,
         "Yosys.Synthesis": Yosys.VHDLSynthesis,
         "Odb.SetPowerConnections": None,


### PR DESCRIPTION
* Created `Checker.NetlistAssignStatements`
  * Outputs warnings or errors (depending on `ERROR_ON_NL_ASSIGN_STATEMENTS`) when `assign` statements are found in the netlist of the input state (assign statements cause some issues with some tools)

## Misc. Enhancements/Bugfixes
* Removed loop header genvar declaration from examples (limited compatibility with some tools)

---
Resolves #512