### PR TITLE
Backwards Compatibility Fixes

### DIFF
--- a/.github/actions/build_nix/action.yml
+++ b/.github/actions/build_nix/action.yml
@@ -28,7 +28,7 @@ inputs:
   pdk_root:
     description: "An optional override for the PDK root."
     required: false
-    default: "~/.volare"
+    default: "$HOME/.volare"
 runs:
   using: "composite"
   steps:

--- a/.github/actions/build_nix/action.yml
+++ b/.github/actions/build_nix/action.yml
@@ -30,7 +30,7 @@ runs:
   steps:
     - id: cache
       name: Cache Derivation
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         key: ${{ inputs.local_cache_key }}-${{ inputs.nix_system }}
         path: /tmp/${{ inputs.local_cache_key }}

--- a/.github/actions/build_nix/action.yml
+++ b/.github/actions/build_nix/action.yml
@@ -25,12 +25,16 @@ inputs:
     description: Whether to run unit tests and the smoke test
     required: false
     default: "false"
+  pdk_root:
+    description: "An optional override for the PDK root."
+    required: false
+    default: "~/.volare"
 runs:
   using: "composite"
   steps:
     - id: cache
       name: Cache Derivation
-      uses: actions/cache@v4
+      uses: actions/cache@v3
       with:
         key: ${{ inputs.local_cache_key }}-${{ inputs.nix_system }}
         path: /tmp/${{ inputs.local_cache_key }}
@@ -62,7 +66,7 @@ runs:
           --option system ${{ inputs.nix_system }}\
           --extra-platforms ${{ inputs.nix_system }}\
           --accept-flake-config\
-          .#packages.${{ inputs.nix_system }}.openlane -- --smoke-test
+          .#packages.${{ inputs.nix_system }}.openlane -- --pdk-root ${{ inputs.pdk_root }} --smoke-test
     - name: Unit/Step Tests
       shell: ${{ inputs.shell }}
       if: inputs.run_tests == 'true'
@@ -72,7 +76,8 @@ runs:
           --option system ${{ inputs.nix_system }}\
           --extra-platforms ${{ inputs.nix_system }}\
           --accept-flake-config\
-          .#devShells.${{ inputs.nix_system }}.dev --command pytest --step-rx '.' -n auto
+          .#devShells.${{ inputs.nix_system }}.dev --command\
+          pytest --step-rx '.' -n auto --pdk-root ${{ inputs.pdk_root }}
     - name: Push to local cache
       shell: ${{ inputs.shell }}
       if: inputs.local_cache_key != '' && steps.cache.outputs.cache-hit != 'true'
@@ -85,6 +90,6 @@ runs:
       if: ${{ inputs.cachix_token != '' }}
       run: |
         echo "#################################################################"
-        nix-env -iA cachix -f https://cachix.org/api/v1/install
+        nix profile install cachix
         cachix authtoken ${{ inputs.cachix_token }}
         cachix push ${{ inputs.cachix_cache }} ${{ steps.build.outputs.out-path }}

--- a/.github/actions/build_nix/action.yml
+++ b/.github/actions/build_nix/action.yml
@@ -77,7 +77,7 @@ runs:
           --extra-platforms ${{ inputs.nix_system }}\
           --accept-flake-config\
           .#devShells.${{ inputs.nix_system }}.dev --command\
-          pytest --step-rx '.' -n auto --pdk-root ${{ inputs.pdk_root }}
+          pytest --step-rx '.' --pdk-root="${{ inputs.pdk_root }}" -n auto
     - name: Push to local cache
       shell: ${{ inputs.shell }}
       if: inputs.local_cache_key != '' && steps.cache.outputs.cache-hit != 'true'

--- a/.github/actions/setup_env/action.yml
+++ b/.github/actions/setup_env/action.yml
@@ -15,14 +15,21 @@ runs:
       shell: bash
       run: echo "NEW_TAG=NO_NEW_TAG" >> $GITHUB_ENV
 
+    - name: Check if publishing branch
+      shell: bash
+      run: |
+        if [[ "$BRANCH_NAME" == "main" || "$BRANCH_NAME" == version* ]]; then
+          echo "PUBLISHING_BRANCH=1" >> $GITHUB_ENV
+        fi
+
     - name: Check for new version
-      if: ${{ github.event_name == 'push' && env.BRANCH_NAME == 'main' }}
+      if: ${{ github.event_name == 'push' && env.PUBLISHING_BRANCH == '1' }}
       shell: bash
       run: |
         python3 ./.github/scripts/generate_tag.py
 
     - name: Publish
-      if: ${{ github.event_name == 'push' && env.BRANCH_NAME == 'main' && env.NEW_TAG != 'NO_NEW_TAG' }}
+      if: ${{ github.event_name == 'push' && env.PUBLISHING_BRANCH == '1' && env.NEW_TAG != 'NO_NEW_TAG' }}
       shell: bash
       run: |
         echo "PUBLISH=1" >> $GITHUB_ENV

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,7 +199,8 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: artifact-sky130-pdk-${{ needs.prepare-test-matrices.outputs.opdks_rev }}
-          path: ${{ env.HOME }}/.volare
+          path: /Users/runner/.volare
+      - run: ls /Users/runner/.volare
       - name: Build with Nix
         uses: ./.github/actions/build_nix
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,6 +184,7 @@ jobs:
           extra-experimental-features = nix-command flakes
           extra-substituters = https://openlane.cachix.org
           extra-trusted-public-keys = openlane.cachix.org-1:qqdwh+QMNGmZAuyeQJTH9ErW57OWSvdtuwfBKdS254E=
+          access-tokens = github.com=${{ env.GITHUB_TOKEN }}
           EXTRA_NIX_CONF
 
           . '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,7 +199,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: artifact-sky130-pdk-${{ needs.prepare-test-matrices.outputs.opdks_rev }}
-          path: ${{ github.workspace }}/.volare
+          path: ${{ env.HOME }}/.volare
       - name: Build with Nix
         uses: ./.github/actions/build_nix
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,6 +183,22 @@ jobs:
     name: Build (Nix/${{ matrix.system.nix }})
     steps:
       - uses: actions/checkout@v3
+      - name: Initialize Step Unit Test Submodule
+        run: |
+          git submodule update --init test/steps/all
+      - name: Set up GITHUB_TOKEN
+        run: |
+          echo "GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}" >> $GITHUB_ENV
+      - name: Install Nix
+        run: |
+          sh <(curl -L https://nixos.org/nix/install) --yes --nix-extra-conf-file /dev/stdin <<EXTRA_NIX_CONF
+          extra-experimental-features = nix-command flakes
+          extra-substituters = https://openlane.cachix.org
+          extra-trusted-public-keys = openlane.cachix.org-1:qqdwh+QMNGmZAuyeQJTH9ErW57OWSvdtuwfBKdS254E=
+          EXTRA_NIX_CONF
+
+          . '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh'
+          echo "PATH=$PATH" >> $GITHUB_ENV
       # For some reason, GHA Macs are far more aggressively rate-limited with
       # Volare than Linux.
       - name: Cache sky130 PDK
@@ -194,62 +210,12 @@ jobs:
       - name: Enable sky130 PDK
         if: steps.cache-sky130-pdk.outputs.cache-hit != 'true'
         run: |
-          pip3 install poetry poetry-plugin-export
-          poetry export --with dev --without-hashes --format=requirements.txt --output=requirements_tmp.txt
-          pip3 install -r requirements_tmp.txt
           export GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
-          volare enable --pdk sky130 --pdk-root ${{ github.workspace }}/.volare-sky130 ${{ needs.prepare-test-matrices.outputs.opdks_rev }}
-      - name: Initialize Step Unit Test Submodule
-        run: |
-          git submodule update --init test/steps/all
-      - name: Set up GITHUB_TOKEN
-        run: |
-          echo "GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}" >> $GITHUB_ENV
-      - name: Install Nix
-        run: |
-          sh <(curl -L https://nixos.org/nix/install) --yes --nix-extra-conf-file /dev/stdin <<EXTRA_NIX_CONF
-          extra-experimental-features = nix-command flakes
-          extra-substituters = https://openlane.cachix.org
-          extra-trusted-public-keys = openlane.cachix.org-1:qqdwh+QMNGmZAuyeQJTH9ErW57OWSvdtuwfBKdS254E=
-          EXTRA_NIX_CONF
-
-          . '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh'
-          echo "PATH=$PATH" >> $GITHUB_ENV
+          nix run github:efabless/volare -- enable --pdk sky130 --pdk-root ${{ github.workspace }}/.volare-sky130 ${{ needs.prepare-test-matrices.outputs.opdks_rev }}
       - name: Build with Nix
         uses: ./.github/actions/build_nix
         with:
           nix_system: ${{ matrix.system.nix }}
-          local_cache_key: derivation-${{ github.run_id }}
-          cachix_cache: ${{ vars.CACHIX_CACHE || 'openlane' }}
-          cachix_token: "${{ secrets.CACHIX_TOKEN }}"
-          shell: "zsh {0}"
-          run_tests: "true"
-  build-mac-aarch64:
-    needs: lint
-    runs-on: macos-14
-    name: Build (Nix on macOS/aarch64)
-    steps:
-      - uses: actions/checkout@v3
-      - name: Initialize Step Unit Test Submodule
-        run: |
-          git submodule update --init test/steps/all
-      - name: Set up GITHUB_TOKEN
-        run: |
-          echo "GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}" >> $GITHUB_ENV
-      - name: Install Nix
-        run: |
-          sh <(curl -L https://nixos.org/nix/install) --yes --nix-extra-conf-file /dev/stdin <<EXTRA_NIX_CONF
-          extra-experimental-features = nix-command flakes
-          extra-substituters = https://openlane.cachix.org
-          extra-trusted-public-keys = openlane.cachix.org-1:qqdwh+QMNGmZAuyeQJTH9ErW57OWSvdtuwfBKdS254E=
-          EXTRA_NIX_CONF
-
-          . '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh'
-          echo "PATH=$PATH" >> $GITHUB_ENV
-      - name: Build with Nix
-        uses: ./.github/actions/build_nix
-        with:
-          nix_system: aarch64-darwin
           local_cache_key: derivation-${{ github.run_id }}
           cachix_cache: ${{ vars.CACHIX_CACHE || 'openlane' }}
           cachix_token: "${{ secrets.CACHIX_TOKEN }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,7 @@ jobs:
   build-linux-amd64:
     needs: lint
     runs-on: ubuntu-22.04
-    name: Build (Nix on Linux/amd64)
+    name: Build (Nix/x86_64-linux)
     steps:
       - uses: actions/checkout@v3
       - name: Initialize Step Unit Test Submodule
@@ -151,7 +151,7 @@ jobs:
   build-linux-aarch64:
     needs: lint
     runs-on: ubuntu-22.04
-    name: Build (Nix on Linux/aarch64)
+    name: Build (Nix/aarch64-linux)
     steps:
       - uses: docker/setup-qemu-action@v1
       - uses: actions/checkout@v3
@@ -170,12 +170,35 @@ jobs:
           cachix_cache: ${{ vars.CACHIX_CACHE || 'openlane' }}
           cachix_token: "${{ secrets.CACHIX_TOKEN }}"
           run_tests: "true"
-  build-mac-amd64:
+  build-mac:
+    strategy:
+      matrix:
+        system:
+          [
+            { gha: macos-13, nix: "x86_64-darwin" },
+            { gha: macos-14, nix: "aarch64-darwin" },
+          ]
     needs: lint
-    runs-on: macos-12
-    name: Build (Nix on macOS/amd64)
+    runs-on: ${{ matrix.system.gha }}
+    name: Build (Nix/${{ matrix.system.nix }})
     steps:
       - uses: actions/checkout@v3
+      # For some reason, GHA Macs are far more aggressively rate-limited with
+      # Volare than Linux.
+      - name: Cache sky130 PDK
+        id: cache-sky130-pdk
+        uses: actions/cache@v3
+        with:
+          path: ${{ github.workspace }}/.volare-sky130
+          key: cache-sky130-pdk-${{ needs.prepare-test-matrices.outputs.opdks_rev }}
+      - name: Enable sky130 PDK
+        if: steps.cache-sky130-pdk.outputs.cache-hit != 'true'
+        run: |
+          pip3 install poetry poetry-plugin-export
+          poetry export --with dev --without-hashes --format=requirements.txt --output=requirements_tmp.txt
+          pip3 install -r requirements_tmp.txt
+          export GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
+          volare enable --pdk sky130 --pdk-root ${{ github.workspace }}/.volare-sky130 ${{ needs.prepare-test-matrices.outputs.opdks_rev }}
       - name: Initialize Step Unit Test Submodule
         run: |
           git submodule update --init test/steps/all
@@ -195,7 +218,7 @@ jobs:
       - name: Build with Nix
         uses: ./.github/actions/build_nix
         with:
-          nix_system: x86_64-darwin
+          nix_system: ${{ matrix.system.nix }}
           local_cache_key: derivation-${{ github.run_id }}
           cachix_cache: ${{ vars.CACHIX_CACHE || 'openlane' }}
           cachix_token: "${{ secrets.CACHIX_TOKEN }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,28 +45,23 @@ jobs:
       - name: Cache sky130 PDK
         uses: actions/cache@v4
         with:
-          path: ${{ github.workspace }}/.volare-sky130
+          path: ./.volare-sky130
           key: cache-sky130-pdk-${{ steps.set-rev.outputs.opdks_rev }}
           enableCrossOsArchive: true
       - name: Enable sky130 PDK
         run: |
           export GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
-          volare enable --pdk sky130 --pdk-root ${{ github.workspace }}/.volare-sky130 ${{ steps.set-rev.outputs.opdks_rev }}
+          volare enable --pdk sky130 --pdk-root ./.volare-sky130 ${{ steps.set-rev.outputs.opdks_rev }}
       - name: Cache gf180mcu PDK
         uses: actions/cache@v4
         with:
-          path: ${{ github.workspace }}/.volare-gf180mcu
+          path: ./.volare-gf180mcu
           key: cache-gf180mcu-pdk-${{ steps.set-rev.outputs.opdks_rev }}
           enableCrossOsArchive: true
       - name: Enable gf180mcu PDK
         run: |
           export GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
-          volare enable --pdk gf180mcu --pdk-root ${{ github.workspace }}/.volare-gf180mcu ${{ steps.set-rev.outputs.opdks_rev }}
-      - name: Sky130 Artifact for Macs Because Cache is Broken
-        uses: actions/upload-artifact@v4
-        with:
-          name: artifact-sky130-pdk-${{ steps.set-rev.outputs.opdks_rev }}
-          path: ${{ github.workspace }}/.volare-sky130
+          volare enable --pdk gf180mcu --pdk-root ./.volare-gf180mcu ${{ steps.set-rev.outputs.opdks_rev }}
       - name: Download IPM
         run: |
           python3 -m pip install git+https://github.com/efabless/IPM
@@ -108,7 +103,7 @@ jobs:
         run: |
           make venv
 
-          ./venv/bin/coverage run -m pytest -n auto --pdk-root="${{ github.workspace }}/.volare-sky130"
+          ./venv/bin/coverage run -m pytest -n auto --pdk-root="./.volare-sky130"
           ./venv/bin/coverage report
           ./venv/bin/coverage html
   build-linux-amd64:
@@ -194,13 +189,13 @@ jobs:
           . '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh'
           echo "PATH=$PATH" >> $GITHUB_ENV
       # For some reason, GHA Macs are far more aggressively rate-limited with
-      # Volare than Linux and cross-OS caches are broken
-      - name: Sky130 Artifact for Macs Because Cache is Broken
-        uses: actions/download-artifact@v4
+      # Volare than Linux
+      - name: Cache sky130 PDK
+        uses: actions/cache@v4
         with:
-          name: artifact-sky130-pdk-${{ needs.prepare-test-matrices.outputs.opdks_rev }}
-          path: /Users/runner/.volare
-      - run: ls /Users/runner/.volare
+          path: ./.volare-sky130
+          key: cache-sky130-pdk-${{ steps.set-rev.outputs.opdks_rev }}
+          enableCrossOsArchive: true
       - name: Build with Nix
         uses: ./.github/actions/build_nix
         with:
@@ -210,6 +205,7 @@ jobs:
           cachix_token: "${{ secrets.CACHIX_TOKEN }}"
           shell: "zsh {0}"
           run_tests: "true"
+          pdk_root: ./.volare-sky130
   build-docker:
     runs-on: ubuntu-22.04
     strategy:
@@ -276,7 +272,7 @@ jobs:
           ./venv/bin/python3 -m openlane\
             --docker-no-tty\
             --dockerized\
-            --pdk-root ${{ github.workspace }}/.volare-sky130\
+            --pdk-root ./.volare-sky130\
             --smoke-test
       - name: Upload Docker Artifact
         uses: actions/upload-artifact@v3
@@ -325,7 +321,7 @@ jobs:
         id: cache-pdk
         uses: actions/cache@v4
         with:
-          path: ${{ github.workspace }}/.volare-${{ matrix.design.pdk_family }}
+          path: ./.volare-${{ matrix.design.pdk_family }}
           key: cache-${{ matrix.design.pdk_family }}-pdk-${{ needs.prepare-test-matrices.outputs.opdks_rev }}
           enableCrossOsArchive: true
       - name: Enable PDKs
@@ -335,7 +331,7 @@ jobs:
           poetry export --with dev --without-hashes --format=requirements.txt --output=requirements_tmp.txt
           pip3 install -r requirements_tmp.txt
           volare enable --pdk ${{ matrix.design.pdk_family }} \
-            --pdk-root ${{ github.workspace }}/.volare-${{ matrix.design.pdk_family }} \
+            --pdk-root ./.volare-${{ matrix.design.pdk_family }} \
             ${{ needs.prepare-test-matrices.outputs.opdks_rev }}
 
       - name: Download IPM designs
@@ -357,7 +353,7 @@ jobs:
               --run-tag ${{ matrix.design.pdk }}-${{ matrix.design.scl }}\
               --pdk ${{ matrix.design.pdk }}\
               --scl ${{ matrix.design.scl }}\
-              --pdk-root ${{ github.workspace }}/.volare-${{ matrix.design.pdk_family }}\
+              --pdk-root ./.volare-${{ matrix.design.pdk_family }}\
               --condensed\
               ${{ matrix.design.config }}
           else
@@ -366,7 +362,7 @@ jobs:
               --run-tag ${{ matrix.design.pdk }}-${{ matrix.design.scl }}\
               --pdk ${{ matrix.design.pdk }}\
               --scl ${{ matrix.design.scl }}\
-              --pdk-root ${{ github.workspace }}/.volare-${{ matrix.design.pdk_family }}\
+              --pdk-root ./.volare-${{ matrix.design.pdk_family }}\
               --condensed
           fi
       - name: Upload Run Folder

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,11 @@ jobs:
         run: |
           export GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
           volare enable --pdk gf180mcu --pdk-root ${{ github.workspace }}/.volare-gf180mcu ${{ steps.set-rev.outputs.opdks_rev }}
+      - name: Sky130 Artifact for Macs Because Cache is Broken
+        uses: actions/upload-artifact@v4
+        with:
+          name: artifact-sky130-pdk-${{ steps.set-rev.outputs.opdks_rev }}
+          path: ${{ github.workspace }}/.volare-sky130
       - name: Download IPM
         run: |
           python3 -m pip install git+https://github.com/efabless/IPM
@@ -99,21 +104,11 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Cache sky130 PDK
-        id: cache-sky130-pdk
-        uses: actions/cache@v4
+      - name: Sky130 Artifact for Macs Because Cache is Broken
+        uses: actions/upload-artifact@v4
         with:
-          path: ${{ github.workspace }}/.volare-sky130
-          key: cache-sky130-pdk-${{ needs.prepare-test-matrices.outputs.opdks_rev }}
-          enableCrossOsArchive: true
-      - name: Enable sky130 PDK
-        if: steps.cache-sky130-pdk.outputs.cache-hit != 'true'
-        run: |
-          pip3 install poetry poetry-plugin-export
-          poetry export --with dev --without-hashes --format=requirements.txt --output=requirements_tmp.txt
-          pip3 install -r requirements_tmp.txt
-          export GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
-          volare enable --pdk sky130 --pdk-root ${{ github.workspace }}/.volare-sky130 ${{ needs.prepare-test-matrices.outputs.opdks_rev }}
+          name: cache-sky130-pdk-${{ needs.prepare-test-matrices.outputs.opdks_rev }}
+          path: ${{ github.workspace }}/.volare
       - name: Run Unit Tests
         run: |
           make venv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           echo "opdks_rev=$(cat ./openlane/open_pdks_rev)" >> $GITHUB_OUTPUT
       - name: Cache sky130 PDK
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ github.workspace }}/.volare-sky130
           key: cache-sky130-pdk-${{ steps.set-rev.outputs.opdks_rev }}
@@ -53,7 +53,7 @@ jobs:
           export GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
           volare enable --pdk sky130 --pdk-root ${{ github.workspace }}/.volare-sky130 ${{ steps.set-rev.outputs.opdks_rev }}
       - name: Cache gf180mcu PDK
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ github.workspace }}/.volare-gf180mcu
           key: cache-gf180mcu-pdk-${{ steps.set-rev.outputs.opdks_rev }}
@@ -101,7 +101,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Cache sky130 PDK
         id: cache-sky130-pdk
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ github.workspace }}/.volare-sky130
           key: cache-sky130-pdk-${{ needs.prepare-test-matrices.outputs.opdks_rev }}
@@ -132,7 +132,7 @@ jobs:
           git submodule update --init test/steps/all
       - name: Set up GITHUB_TOKEN
         run: |
-          echo "GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}" >> $GITHUB_ENV
+          echo "GITHUB_TOKEN=${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}" >> $GITHUB_ENV
       - name: Install Nix
         run: |
           sh <(curl -L https://nixos.org/nix/install) --yes --daemon --nix-extra-conf-file /dev/stdin <<EXTRA_NIX_CONF
@@ -163,7 +163,7 @@ jobs:
           git submodule update --init test/steps/all
       - name: Set up GITHUB_TOKEN
         run: |
-          echo "GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}" >> $GITHUB_ENV
+          echo "GITHUB_TOKEN=${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}" >> $GITHUB_ENV
       - uses: DeterminateSystems/nix-installer-action@main # Using the DS Nix installer because it also sets up binfmt
       - name: Build with Nix
         uses: ./.github/actions/build_nix
@@ -173,7 +173,7 @@ jobs:
           cachix_cache: ${{ vars.CACHIX_CACHE || 'openlane' }}
           cachix_token: "${{ secrets.CACHIX_TOKEN }}"
           run_tests: "true"
-  build-mac:
+  build-darwin:
     strategy:
       matrix:
         system:
@@ -191,7 +191,7 @@ jobs:
           git submodule update --init test/steps/all
       - name: Set up GITHUB_TOKEN
         run: |
-          echo "GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}" >> $GITHUB_ENV
+          echo "GITHUB_TOKEN=${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}" >> $GITHUB_ENV
       - name: Install Nix
         run: |
           sh <(curl -L https://nixos.org/nix/install) --yes --nix-extra-conf-file /dev/stdin <<EXTRA_NIX_CONF
@@ -206,7 +206,7 @@ jobs:
       # Volare than Linux.
       - name: Cache sky130 PDK
         id: cache-sky130-pdk
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ github.workspace }}/.volare-sky130
           key: cache-sky130-pdk-${{ needs.prepare-test-matrices.outputs.opdks_rev }}
@@ -340,7 +340,7 @@ jobs:
           sudo tree /nix/store/*-openlane2 || true
       - name: Cache PDK
         id: cache-pdk
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ github.workspace }}/.volare-${{ matrix.design.pdk_family }}
           key: cache-${{ matrix.design.pdk_family }}-pdk-${{ needs.prepare-test-matrices.outputs.opdks_rev }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,11 +104,6 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Sky130 Artifact for Macs Because Cache is Broken
-        uses: actions/upload-artifact@v4
-        with:
-          name: cache-sky130-pdk-${{ needs.prepare-test-matrices.outputs.opdks_rev }}
-          path: ${{ github.workspace }}/.volare
       - name: Run Unit Tests
         run: |
           make venv
@@ -199,21 +194,12 @@ jobs:
           . '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh'
           echo "PATH=$PATH" >> $GITHUB_ENV
       # For some reason, GHA Macs are far more aggressively rate-limited with
-      # Volare than Linux.
-      - name: Cache sky130 PDK
-        id: cache-sky130-pdk
-        uses: actions/cache@v4
+      # Volare than Linux and cross-OS caches are broken
+      - name: Sky130 Artifact for Macs Because Cache is Broken
+        uses: actions/download-artifact@v4
         with:
-          path: ${{ github.workspace }}/.volare-sky130
-          key: cache-sky130-pdk-${{ needs.prepare-test-matrices.outputs.opdks_rev }}
-          enableCrossOsArchive: true
-      - name: Enable sky130 PDK
-        if: steps.cache-sky130-pdk.outputs.cache-hit != 'true'
-        run: |
-          brew install dasel
-          python3 -m venv venv
-          ./venv/bin/python3 -m pip install "volare$(cat ./pyproject.toml | dasel -r toml 'tool.poetry.dependencies.volare' --pretty -w plain)"
-          ./venv/bin/volare enable --pdk sky130 --pdk-root ${{ github.workspace }}/.volare-sky130 ${{ needs.prepare-test-matrices.outputs.opdks_rev }}
+          name: cache-sky130-pdk-${{ needs.prepare-test-matrices.outputs.opdks_rev }}
+          path: ${{ github.workspace }}/.volare
       - name: Build with Nix
         uses: ./.github/actions/build_nix
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,7 +178,7 @@ jobs:
             { gha: macos-13, nix: "x86_64-darwin" },
             { gha: macos-14, nix: "aarch64-darwin" },
           ]
-    needs: lint
+    needs: [lint, prepare-test-matrices]
     runs-on: ${{ matrix.system.gha }}
     name: Build (Nix/${{ matrix.system.nix }})
     steps:
@@ -210,8 +210,10 @@ jobs:
       - name: Enable sky130 PDK
         if: steps.cache-sky130-pdk.outputs.cache-hit != 'true'
         run: |
-          export GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
-          nix run github:efabless/volare -- enable --pdk sky130 --pdk-root ${{ github.workspace }}/.volare-sky130 ${{ needs.prepare-test-matrices.outputs.opdks_rev }}
+          brew install dasel
+          python3 -m venv venv
+          ./venv/bin/python3 -m pip install "volare$(cat ./pyproject.toml | dasel -r toml 'tool.poetry.version' --pretty -w plain)""
+          ./venv/bin/volare enable --pdk sky130 --pdk-root ${{ github.workspace }}/.volare-sky130 ${{ needs.prepare-test-matrices.outputs.opdks_rev }}
       - name: Build with Nix
         uses: ./.github/actions/build_nix
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,6 +181,7 @@ jobs:
             { gha: macos-13, nix: "x86_64-darwin" },
             { gha: macos-14, nix: "aarch64-darwin" },
           ]
+      fail-fast: false
     needs: [lint, prepare-test-matrices]
     runs-on: ${{ matrix.system.gha }}
     name: Build (Nix/${{ matrix.system.nix }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,7 +212,7 @@ jobs:
         run: |
           brew install dasel
           python3 -m venv venv
-          ./venv/bin/python3 -m pip install "volare$(cat ./pyproject.toml | dasel -r toml 'tool.poetry.version' --pretty -w plain)""
+          ./venv/bin/python3 -m pip install "volare$(cat ./pyproject.toml | dasel -r toml 'tool.poetry.version' --pretty -w plain)"
           ./venv/bin/volare enable --pdk sky130 --pdk-root ${{ github.workspace }}/.volare-sky130 ${{ needs.prepare-test-matrices.outputs.opdks_rev }}
       - name: Build with Nix
         uses: ./.github/actions/build_nix

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,7 +205,7 @@ jobs:
           cachix_token: "${{ secrets.CACHIX_TOKEN }}"
           shell: "zsh {0}"
           run_tests: "true"
-          pdk_root: ./.volare-sky130
+          pdk_root: ${{ github.workspace }}/.volare-sky130
   build-docker:
     runs-on: ubuntu-22.04
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,7 +198,7 @@ jobs:
       - name: Sky130 Artifact for Macs Because Cache is Broken
         uses: actions/download-artifact@v4
         with:
-          name: cache-sky130-pdk-${{ needs.prepare-test-matrices.outputs.opdks_rev }}
+          name: artifact-sky130-pdk-${{ needs.prepare-test-matrices.outputs.opdks_rev }}
           path: ${{ github.workspace }}/.volare
       - name: Build with Nix
         uses: ./.github/actions/build_nix

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,7 +212,7 @@ jobs:
         run: |
           brew install dasel
           python3 -m venv venv
-          ./venv/bin/python3 -m pip install "volare$(cat ./pyproject.toml | dasel -r toml 'tool.poetry.version' --pretty -w plain)"
+          ./venv/bin/python3 -m pip install "volare$(cat ./pyproject.toml | dasel -r toml 'tool.poetry.dependencies.volare' --pretty -w plain)"
           ./venv/bin/volare enable --pdk sky130 --pdk-root ${{ github.workspace }}/.volare-sky130 ${{ needs.prepare-test-matrices.outputs.opdks_rev }}
       - name: Build with Nix
         uses: ./.github/actions/build_nix

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,7 @@ jobs:
         with:
           path: ${{ github.workspace }}/.volare-sky130
           key: cache-sky130-pdk-${{ steps.set-rev.outputs.opdks_rev }}
+          enableCrossOsArchive: true
       - name: Enable sky130 PDK
         run: |
           export GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
@@ -56,6 +57,7 @@ jobs:
         with:
           path: ${{ github.workspace }}/.volare-gf180mcu
           key: cache-gf180mcu-pdk-${{ steps.set-rev.outputs.opdks_rev }}
+          enableCrossOsArchive: true
       - name: Enable gf180mcu PDK
         run: |
           export GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
@@ -103,6 +105,7 @@ jobs:
         with:
           path: ${{ github.workspace }}/.volare-sky130
           key: cache-sky130-pdk-${{ needs.prepare-test-matrices.outputs.opdks_rev }}
+          enableCrossOsArchive: true
       - name: Enable sky130 PDK
         if: steps.cache-sky130-pdk.outputs.cache-hit != 'true'
         run: |
@@ -207,6 +210,7 @@ jobs:
         with:
           path: ${{ github.workspace }}/.volare-sky130
           key: cache-sky130-pdk-${{ needs.prepare-test-matrices.outputs.opdks_rev }}
+          enableCrossOsArchive: true
       - name: Enable sky130 PDK
         if: steps.cache-sky130-pdk.outputs.cache-hit != 'true'
         run: |
@@ -334,15 +338,15 @@ jobs:
         run: |
           sudo du -hs /nix/store/* | sort -h | tail -n 10
           sudo tree /nix/store/*-openlane2 || true
-      - name: Cache PDKs
-        id: cache-pdks
+      - name: Cache PDK
+        id: cache-pdk
         uses: actions/cache@v3
         with:
           path: ${{ github.workspace }}/.volare-${{ matrix.design.pdk_family }}
           key: cache-${{ matrix.design.pdk_family }}-pdk-${{ needs.prepare-test-matrices.outputs.opdks_rev }}
-
+          enableCrossOsArchive: true
       - name: Enable PDKs
-        if: steps.cache-pdks.outputs.cache-hit != 'true'
+        if: steps.cache-pdk.outputs.cache-hit != 'true'
         run: |
           pip3 install poetry poetry-plugin-export
           poetry export --with dev --without-hashes --format=requirements.txt --output=requirements_tmp.txt

--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,27 @@
 ## Documentation
 -->
 
+# 2.1.1
+
+## Steps
+
+* `Odb.SetPowerConnections`
+
+  * Internally reworked pin detection behavior so power pins are found in the
+    LEF first then matched in the Verilog, fixing a corner-cases where
+    unconnected buses would be candidates for power pins, then promptly cause a
+    crash as they only exist in the layout as separate pins.
+
+* `OpenROAD.IOPlacement`, `OpenROAD.GlobalPlacementSkipIO`
+
+  * `FP_IO_MODE` renamed to `FP_PPL_MODE`: translation behavior for OpenLane
+    1-style FP_IO_MODE with integers added behind deprecated name `FP_IO_MODE`.
+
+* `Yosys.*Synthesis`
+
+  * Restored filtering of `defparam` from output netlists to avoid surprisingly
+    still extant OpenSTA limitation.
+
 # 2.1.0: The "Customization and Control" Update
 
 ## CLI

--- a/Changelog.md
+++ b/Changelog.md
@@ -35,6 +35,19 @@
   * Restored filtering of `defparam` from output netlists to avoid surprisingly
     still extant OpenSTA limitation.
 
+## Testing
+
+* Added file to exclude step unit tests purely to speed-up turnaround time for
+  PRs (as sometimes a test would need to be deleted/temporarily disabled without
+  updating the submodule, see #475 for a similar situation)
+
+* Mac CI now uses an artifact of the PDK
+
+  * Unlike the Linux runners, Mac runners:
+    * Are disproportionately affected by rate-limiting: cannot pull from GitHub
+      using Volare
+    * Do not support caches created on Ubuntu, even with `enableCrossOsArchive`
+
 # 2.1.0: The "Customization and Control" Update
 
 ## CLI

--- a/openlane/common/__init__.py
+++ b/openlane/common/__init__.py
@@ -43,6 +43,7 @@ from .misc import (
     Filter,
     get_latest_file,
     process_list_file,
+    _get_process_limit,
 )
 from .types import (
     is_number,

--- a/openlane/common/misc.py
+++ b/openlane/common/misc.py
@@ -370,3 +370,7 @@ def process_list_file(from_file: AnyPath) -> List[str]:
             continue
         excluded_cells.append(line)
     return excluded_cells
+
+
+def _get_process_limit() -> int:
+    return int(os.getenv("_OPENLANE_MAX_CORES", os.cpu_count() or 1))

--- a/openlane/common/tpe.py
+++ b/openlane/common/tpe.py
@@ -11,11 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
+from .misc import _get_process_limit
 
 from concurrent.futures import ThreadPoolExecutor
 
-TPE = ThreadPoolExecutor(max_workers=os.cpu_count())
+TPE = ThreadPoolExecutor(max_workers=_get_process_limit())
 
 
 def set_tpe(tpe: ThreadPoolExecutor):

--- a/openlane/flows/cli.py
+++ b/openlane/flows/cli.py
@@ -16,7 +16,6 @@ from functools import partial, wraps
 from concurrent.futures import ThreadPoolExecutor
 from typing import Optional, Union
 
-
 from click import (
     Context,
     Parameter,
@@ -35,7 +34,7 @@ from cloup.constraints import (
 from cloup.typing import Decorator
 
 from .flow import Flow
-from ..common import set_tpe, cli, get_opdks_rev
+from ..common import set_tpe, cli, get_opdks_rev, _get_process_limit
 from ..logging import set_log_level, verbose, err, options, LogLevels
 from ..state import State, InvalidState
 
@@ -369,7 +368,7 @@ def cloup_flow_opts(
                 "-j",
                 "--jobs",
                 type=int,
-                default=os.cpu_count(),
+                default=_get_process_limit(),
                 help="The maximum number of threads or processes that can be used by OpenLane.",
                 callback=set_worker_count_cb,
                 expose_value=False,

--- a/openlane/scripts/odbpy/power_utils.py
+++ b/openlane/scripts/odbpy/power_utils.py
@@ -97,11 +97,8 @@ class Design(object):
         connections = cells[cell_name]["connections"]
         for pin_name, sigtype in lef_pg_pins:
             if pin_name not in connections:
-                print(
-                    f"[ERROR] {sigtype} pin {module}/{pin_name} not found in the Verilog view: the LEF and Verilog views of the module may be mismatched."
-                )
-                print("(Note that power/ground buses are not currently supported.)")
-                exit(-1)
+                # Might simply not be connected yet-- ignore
+                continue
             connection_bits = connections[pin_name]
             if len(connection_bits) != 1:
                 print(
@@ -113,14 +110,6 @@ class Design(object):
             if connected_to_v not in self.nets_by_net_name:
                 # Not actually connected - continue
                 continue
-                ## Enforce connections
-                print(
-                    f"[ERROR] Could not find net {connected_to_v} connected to {sigtype} pin {module}/{pin_name}."
-                )
-                print(
-                    "(Ensure that the pin(s) in question are properly connected to power or ground.)"
-                )
-                exit(-1)
             (power_pins if sigtype == "POWER" else ground_pins)[
                 pin_name
             ] = connected_to_v

--- a/openlane/scripts/odbpy/power_utils.py
+++ b/openlane/scripts/odbpy/power_utils.py
@@ -44,11 +44,12 @@ class Design(object):
         self.yosys_design_object = yosys_dict["modules"][self.design_name]
 
         self.pins_by_module_name: Dict[str, Dict[str, odb.dbMTerm]] = {}
-        self.net_name_by_bit: Dict[int, str] = functools.reduce(
+        self.verilog_net_name_by_bit: Dict[int, str] = functools.reduce(
             lambda a, b: {**a, **{bit: b[0] for bit in b[1]["bits"]}},
             self.yosys_design_object["netnames"].items(),
             {},
         )
+        self.nets_by_net_name = {net.getName(): net for net in reader.block.getNets()}
 
     def get_pins(self, module_name: str) -> Dict[str, odb.dbMTerm]:
         if module_name not in self.pins_by_module_name:
@@ -82,51 +83,62 @@ class Design(object):
 
         return module_pins[pin_name].getSigType() == "GROUND"
 
-    def is_bus(self, pin_connections: List) -> bool:
-        return len(pin_connections) > 1
-
-    def extract_power_pins(self, cell_name: str) -> dict:
+    def extract_pg_pins(self, cell_name: str) -> dict:
         cells = self.yosys_design_object["cells"]
         module = cells[cell_name]["type"]
-        non_bus_pins = {
-            pin_name: cells[cell_name]["connections"][pin_name]
-            for pin_name in cells[cell_name]["connections"].keys()
-            if not self.is_bus(cells[cell_name]["connections"][pin_name])
-        }
-        power_pins = {
-            pin_name: non_bus_pins[pin_name]
-            for pin_name in non_bus_pins.keys()
-            if self.is_power(module, pin_name)
-        }
-        for pin_name in power_pins.keys():
-            connection_bits = power_pins[pin_name]
-            assert len(connection_bits) == 1, "Power connection has more than one net"
-            connection_bit = connection_bits[0]
-            power_pins[pin_name] = self.net_name_by_bit[connection_bit]
+        master = self.reader.db.findMaster(module)
+        lef_pg_pins = []
+        for pin in master.getMTerms():
+            if pin.getSigType() in ["POWER", "GROUND"]:
+                lef_pg_pins.append((pin.getName(), pin.getSigType()))
 
-        return power_pins
-
-    def extract_ground_pins(self, cell_name: str) -> dict:
-        cells = self.yosys_design_object["cells"]
-        module = cells[cell_name]["type"]
+        power_pins = {}
+        ground_pins = {}
         connections = cells[cell_name]["connections"]
-        non_bus_pins = {
-            pin_name: connections[pin_name]
-            for pin_name in connections.keys()
-            if not self.is_bus(connections[pin_name])
-        }
-        ground_pins = {
-            pin_name: non_bus_pins[pin_name]
-            for pin_name in non_bus_pins.keys()
-            if self.is_ground(module, pin_name)
-        }
-        for pin_name in ground_pins.keys():
-            connection_bits = ground_pins[pin_name]
-            assert len(connection_bits) == 1, "Ground connection has more than one net"
+        for pin_name, sigtype in lef_pg_pins:
+            if pin_name not in connections:
+                # Not connected - continue
+                continue
+                ## Enforce connections
+                print(
+                    f"[ERROR] {sigtype} pin {module}/{pin_name} not found in the Verilog view: the LEF and Verilog views of the module may be mismatched."
+                )
+                print(f"(Note that power/ground buses are not currently supported.)")
+                exit(-1)
+            connection_bits = connections[pin_name]
+            if len(connection_bits) != 1:
+                print(
+                    f"[ERROR] Unexpectedly found more than one bit connected to {sigtype} pin {module}/{pin_name}."
+                )
+                exit(-1)
             connection_bit = connection_bits[0]
-            ground_pins[pin_name] = self.net_name_by_bit[connection_bit]
+            connected_to_v = self.verilog_net_name_by_bit[connection_bit]
+            if connected_to_v not in self.nets_by_net_name:
+                # Not actually connected - continue
+                continue
+                ## Enforce connections
+                print(
+                    f"[ERROR] Could not find net {connected_to_v} connected to {sigtype} pin {module}/{pin_name}."
+                )
+                print(
+                    "(Ensure that the pin(s) in question are properly connected to power or ground.)"
+                )
+                exit(-1)
+            (power_pins if sigtype == "POWER" else ground_pins)[
+                pin_name
+            ] = connected_to_v
 
-        return ground_pins
+        if len(power_pins) == 0:
+            print(
+                f"[ERROR] No power pins in {module} appear to be connected to valid nets in the powered netlist."
+            )
+            exit(-1)
+        if len(ground_pins) == 0:
+            print(
+                f"[ERROR] No ground pins in {module} appear to be connected to valid nets in the powered netlist."
+            )
+            exit(-1)
+        return power_pins, ground_pins
 
     def extract_instances(self) -> List["Design.Instance"]:
         instances = []
@@ -136,8 +148,7 @@ class Design(object):
             if module.startswith("$"):
                 # yosys primitive
                 continue
-            power_pins = self.extract_power_pins(cell_name)
-            ground_pins = self.extract_ground_pins(cell_name)
+            power_pins, ground_pins = self.extract_pg_pins(cell_name)
             instances.append(
                 Design.Instance(
                     name=cell_name,
@@ -217,7 +228,9 @@ class Design(object):
                 term.getInst().getName() == inst_def_name
                 and term.getMTerm().getName() == pin_def_name
             ):
-                print(f"{inst_name}/{pin_name} is already connected to {net.getName()}")
+                print(
+                    f"[INFO] {inst_name}/{pin_name} is already connected to {net.getName()} in the layout."
+                )
                 return
 
         connected_items = design.getBlock().addGlobalConnect(
@@ -227,7 +240,6 @@ class Design(object):
             net,
             True,
         )
-        print(f"Made {connected_items} connections.")
 
         if connected_items == 0:
             print(
@@ -236,9 +248,11 @@ class Design(object):
             exit(-1)
         elif connected_items > 1:
             print(
-                f"[ERROR] add_global_connections somehow made multiple connections for '{inst_name}/{pin_name}' to {net_name} -- please report this as a bug"
+                f"[ERROR] add_global_connections somehow made {connected_items} connections for '{inst_name}/{pin_name}' to {net_name} -- please report this as a bug"
             )
             exit(-1)
+        else:
+            print(f"[INFO] Successfully connected.")
 
 
 @click.command()

--- a/openlane/scripts/odbpy/power_utils.py
+++ b/openlane/scripts/odbpy/power_utils.py
@@ -103,7 +103,7 @@ class Design(object):
                 print(
                     f"[ERROR] {sigtype} pin {module}/{pin_name} not found in the Verilog view: the LEF and Verilog views of the module may be mismatched."
                 )
-                print(f"(Note that power/ground buses are not currently supported.)")
+                print("(Note that power/ground buses are not currently supported.)")
                 exit(-1)
             connection_bits = connections[pin_name]
             if len(connection_bits) != 1:
@@ -252,7 +252,7 @@ class Design(object):
             )
             exit(-1)
         else:
-            print(f"[INFO] Successfully connected.")
+            print("[INFO] Successfully connected.")
 
 
 @click.command()

--- a/openlane/scripts/odbpy/power_utils.py
+++ b/openlane/scripts/odbpy/power_utils.py
@@ -97,9 +97,6 @@ class Design(object):
         connections = cells[cell_name]["connections"]
         for pin_name, sigtype in lef_pg_pins:
             if pin_name not in connections:
-                # Not connected - continue
-                continue
-                ## Enforce connections
                 print(
                     f"[ERROR] {sigtype} pin {module}/{pin_name} not found in the Verilog view: the LEF and Verilog views of the module may be mismatched."
                 )
@@ -241,6 +238,7 @@ class Design(object):
             True,
         )
 
+        print(f"[INFO] Made {connected_items} connections.")
         if connected_items == 0:
             print(
                 f"[ERROR] add_global_connections failed to make any connections for '{inst_name}/{pin_name}' to {net_name}."
@@ -251,8 +249,6 @@ class Design(object):
                 f"[ERROR] add_global_connections somehow made {connected_items} connections for '{inst_name}/{pin_name}' to {net_name} -- please report this as a bug"
             )
             exit(-1)
-        else:
-            print("[INFO] Successfully connected.")
 
 
 @click.command()

--- a/openlane/scripts/odbpy/power_utils.py
+++ b/openlane/scripts/odbpy/power_utils.py
@@ -97,7 +97,7 @@ class Design(object):
         connections = cells[cell_name]["connections"]
         for pin_name, sigtype in lef_pg_pins:
             if pin_name not in connections:
-                # Might simply not be connected yet-- ignore
+                # Bad Verilog view-- error would break backcompat
                 continue
             connection_bits = connections[pin_name]
             if len(connection_bits) != 1:
@@ -107,23 +107,10 @@ class Design(object):
                 exit(-1)
             connection_bit = connection_bits[0]
             connected_to_v = self.verilog_net_name_by_bit[connection_bit]
-            if connected_to_v not in self.nets_by_net_name:
-                # Not actually connected - continue
-                continue
             (power_pins if sigtype == "POWER" else ground_pins)[
                 pin_name
             ] = connected_to_v
 
-        if len(power_pins) == 0:
-            print(
-                f"[ERROR] No power pins in {module} appear to be connected to valid nets in the powered netlist."
-            )
-            exit(-1)
-        if len(ground_pins) == 0:
-            print(
-                f"[ERROR] No ground pins in {module} appear to be connected to valid nets in the powered netlist."
-            )
-            exit(-1)
         return power_pins, ground_pins
 
     def extract_instances(self) -> List["Design.Instance"]:

--- a/openlane/scripts/openroad/ioplacer.tcl
+++ b/openlane/scripts/openroad/ioplacer.tcl
@@ -40,7 +40,7 @@ if {$::env(FP_IO_VTHICKNESS_MULT) != "" && $::env(FP_IO_HTHICKNESS_MULT) != ""} 
 }
 
 set arg_list [list]
-if { $::env(FP_IO_MODE) == "random_equidistant" } {
+if { $::env(FP_PPL_MODE) == "random_equidistant" } {
 	lappend arg_list -random
 }
 
@@ -48,7 +48,7 @@ if { [info exists ::env(FP_IO_MIN_DISTANCE)] } {
 	lappend arg_list -min_distance $::env(FP_IO_MIN_DISTANCE)
 }
 
-if { $::env(FP_IO_MODE) == "annealing" } {
+if { $::env(FP_PPL_MODE) == "annealing" } {
 	lappend arg_list -annealing
 }
 

--- a/openlane/steps/klayout.py
+++ b/openlane/steps/klayout.py
@@ -26,7 +26,7 @@ from .step import ViewsUpdate, MetricsUpdate, Step, StepError, StepException
 from ..config import Variable
 from ..logging import info
 from ..state import DesignFormat, State
-from ..common import Path, get_script_dir, mkdirp
+from ..common import Path, get_script_dir, mkdirp, _get_process_limit
 
 
 class KLayoutStep(Step):
@@ -296,7 +296,7 @@ class XOR(KLayoutStep):
         if tile_size := self.config["KLAYOUT_XOR_TILE_SIZE"]:
             tile_size_options += ["--tile-size", str(tile_size)]
 
-        thread_count = self.config["KLAYOUT_XOR_THREADS"] or os.cpu_count() or 1
+        thread_count = self.config["KLAYOUT_XOR_THREADS"] or _get_process_limit()
         info(f"Running XOR with {thread_count} threads…")
 
         subprocess_result = self.run_subprocess(
@@ -371,7 +371,7 @@ class DRC(KLayoutStep):
         ).lower()
         offgrid = str(self.config["KLAYOUT_DRC_OPTIONS"]["offgrid"]).lower()
         seal = str(self.config["KLAYOUT_DRC_OPTIONS"]["seal"]).lower()
-        threads = self.config["KLAYOUT_DRC_THREADS"] or (str(os.cpu_count()) or "1")
+        threads = self.config["KLAYOUT_DRC_THREADS"] or _get_process_limit()
         info(f"Running KLayout DRC with {threads} threads…")
 
         input_view = state_in[DesignFormat.GDS]

--- a/openlane/steps/openroad.py
+++ b/openlane/steps/openroad.py
@@ -1289,10 +1289,11 @@ class GlobalPlacementSkipIO(_GlobalPlacement):
 
     config_vars = _GlobalPlacement.config_vars + [
         Variable(
-            "FP_IO_MODE",
+            "FP_PPL_MODE",
             Literal["matching", "random_equidistant", "annealing"],
             "Decides the mode of the random IO placement option.",
             default="matching",
+            deprecated_names=[("FP_IO_MODE", _migrate_ppl_mode)],
         ),
         Variable(
             "FP_DEF_TEMPLATE",

--- a/openlane/steps/yosys.py
+++ b/openlane/steps/yosys.py
@@ -16,6 +16,8 @@ import re
 import io
 import json
 import fnmatch
+import shutil
+import tempfile
 import textwrap
 import subprocess
 from decimal import Decimal
@@ -502,6 +504,31 @@ class SynthesisCommon(YosysStep):
         # )
 
         views_updates, metric_updates = super().run(state_in, env=env, **kwargs)
+
+        # The following is a naive workaround to OpenSTA not accepting defparams.
+        # It *should* be handled with a fix to the OpenSTA Verilog parser.
+        #
+        # This workaround was in OpenLane 1 and turns 4 this November! 🎂
+        # https://github.com/The-OpenROAD-Project/OpenLane/commit/e6bc1ea5
+        defparam_rx = re.compile(r"^\s*defparam\s+[\s\S]+$")
+        defparams_found = False
+        with tempfile.NamedTemporaryFile("w", delete=False) as nodefparams:
+            for line in open(views_updates[DesignFormat.NETLIST], "r"):
+                if defparam_rx.match(line) is not None:
+                    defparams_found = True
+                else:
+                    nodefparams.write(line)
+        if defparams_found:
+            shutil.move(
+                views_updates[DesignFormat.NETLIST],
+                f"{views_updates[DesignFormat.NETLIST]}-defparams",
+            )
+            shutil.move(
+                nodefparams.name,
+                views_updates[DesignFormat.NETLIST],
+            )
+        else:
+            os.unlink(nodefparams.name)
 
         stats_file = os.path.join(self.step_dir, "reports", "stat.json")
         stats_str = open(stats_file).read()

--- a/openlane/steps/yosys.py
+++ b/openlane/steps/yosys.py
@@ -512,21 +512,16 @@ class SynthesisCommon(YosysStep):
         # https://github.com/The-OpenROAD-Project/OpenLane/commit/e6bc1ea5
         defparam_rx = re.compile(r"^\s*defparam\s+[\s\S]+$")
         defparams_found = False
+        nl_path = str(views_updates[DesignFormat.NETLIST])
         with tempfile.NamedTemporaryFile("w", delete=False) as nodefparams:
-            for line in open(views_updates[DesignFormat.NETLIST], "r"):
+            for line in open(nl_path, "r"):
                 if defparam_rx.match(line) is not None:
                     defparams_found = True
                 else:
                     nodefparams.write(line)
         if defparams_found:
-            shutil.move(
-                views_updates[DesignFormat.NETLIST],
-                f"{views_updates[DesignFormat.NETLIST]}-defparams",
-            )
-            shutil.move(
-                nodefparams.name,
-                views_updates[DesignFormat.NETLIST],
-            )
+            shutil.move(nl_path, f"{nl_path}-defparams")
+            shutil.move(nodefparams.name, nl_path)
         else:
             os.unlink(nodefparams.name)
 

--- a/openlane/steps/yosys.py
+++ b/openlane/steps/yosys.py
@@ -517,6 +517,7 @@ class SynthesisCommon(YosysStep):
             for line in open(nl_path, "r"):
                 if defparam_rx.match(line) is not None:
                     defparams_found = True
+                    nodefparams.write(f"// removed: {line}")
                 else:
                     nodefparams.write(line)
         if defparams_found:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openlane"
-version = "2.1.0"
+version = "2.1.1"
 description = "An infrastructure for implementing chip design flows"
 authors = ["Efabless Corporation and Contributors <donn@efabless.com>"]
 readme = "Readme.md"

--- a/test/steps/excluded_step_tests
+++ b/test/steps/excluded_step_tests
@@ -1,0 +1,1 @@
+odb.setpowerconnections/003-fail_mismatched_view


### PR DESCRIPTION
* `Odb.SetPowerConnections`
  * Internally reworked pin detection behavior so power pins are found in the LEF first then matched in the Verilog, fixing a corner-cases where unconnected buses would be candidates for power pins, then promptly cause a crash as they only exist in the layout as separate pins.

* `OpenROAD.IOPlacement`, `OpenROAD.GlobalPlacementSkipIO`
  * `FP_IO_MODE` renamed to `FP_PPL_MODE`: translation behavior for OpenLane 1-style `FP_IO_MODE` with integers added behind deprecated name `FP_IO_MODE`.

* `Yosys.*Synthesis`
  * Restored filtering of `defparam` from output netlists to avoid surprisingly still extant OpenSTA limitation.

## Testing

* Added file to exclude test purely to speed-up turnaround time for PRs (as sometimes a test would need to be deleted/temporarily disabled without updating the submodule, see #475 for a similar situation)
* Mac CI now uses an artifact of the PDK
  * Unlike the Linux runners, Mac. runners:
     * Disproportionately affected by rate-limiting: cannot pull from GitHub using Volare
     * Do not support caches created on Ubuntu, even with `enableCrossOsArchive`
---

Resolves #470 

This issue is to be merged to 2.1.0 and backported to 2.0.X.