### PR TITLE
Add ORFS-inspired Diagram to Readme; use DetSys Nix Installer

### DIFF
--- a/.github/actions/build_nix/action.yml
+++ b/.github/actions/build_nix/action.yml
@@ -42,7 +42,8 @@ runs:
       name: Build
       shell: ${{ inputs.shell }}
       run: |
-        if [ '${{ inputs.local_cache_key }}' = '' ]; then
+        substituters='https://${{ inputs.cachix_cache }}.cachix.org https://cache.nixos.org'
+        if [ '${{ inputs.local_cache_key }}' != '' ]; then
           substituters="file:///tmp/${{ inputs.local_cache_key }} $substituters"
         fi
         echo "#################################################################"

--- a/.github/actions/build_nix/action.yml
+++ b/.github/actions/build_nix/action.yml
@@ -42,7 +42,6 @@ runs:
       name: Build
       shell: ${{ inputs.shell }}
       run: |
-        substituters='https://${{ inputs.cachix_cache }}.cachix.org https://cache.nixos.org'
         if [ '${{ inputs.local_cache_key }}' = '' ]; then
           substituters="file:///tmp/${{ inputs.local_cache_key }} $substituters"
         fi
@@ -53,7 +52,7 @@ runs:
           --accept-flake-config\
           --option system ${{ inputs.nix_system }}\
           --extra-platforms ${{ inputs.nix_system }}\
-          --option substituters "$substituters"\
+          --option extra-substituters "$substituters"\
           .#devShells.${{ inputs.nix_system }}.default)
         echo "out-path=$outPath" >> $GITHUB_OUTPUT
         sudo du -hs /nix/store/* | sort -h | tail -n 20

--- a/.github/actions/build_nix/action.yml
+++ b/.github/actions/build_nix/action.yml
@@ -17,10 +17,6 @@ inputs:
     description: "The nix platform string to build for"
     required: true
     default: "x86_64-linux"
-  local_cache_key:
-    description: Key to use for the cache
-    required: false
-    default: ""
   run_tests:
     description: Whether to run unit tests and the smoke test
     required: false
@@ -32,20 +28,10 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - id: cache
-      name: Cache Derivation
-      uses: actions/cache@v3
-      with:
-        key: ${{ inputs.local_cache_key }}-${{ inputs.nix_system }}
-        path: /tmp/${{ inputs.local_cache_key }}
     - id: Build
       name: Build
       shell: ${{ inputs.shell }}
       run: |
-        substituters='https://${{ inputs.cachix_cache }}.cachix.org https://cache.nixos.org'
-        if [ '${{ inputs.local_cache_key }}' != '' ]; then
-          substituters="file:///tmp/${{ inputs.local_cache_key }} $substituters"
-        fi
         echo "#################################################################"
         outPath=$(nix build\
           --print-out-paths\
@@ -53,7 +39,6 @@ runs:
           --accept-flake-config\
           --option system ${{ inputs.nix_system }}\
           --extra-platforms ${{ inputs.nix_system }}\
-          --option extra-substituters "$substituters"\
           .#devShells.${{ inputs.nix_system }}.default)
         echo "out-path=$outPath" >> $GITHUB_OUTPUT
         sudo du -hs /nix/store/* | sort -h | tail -n 20
@@ -78,13 +63,6 @@ runs:
           --accept-flake-config\
           .#devShells.${{ inputs.nix_system }}.dev --command\
           pytest --step-rx '.' --pdk-root="${{ inputs.pdk_root }}" -n auto
-    - name: Push to local cache
-      shell: ${{ inputs.shell }}
-      if: inputs.local_cache_key != '' && steps.cache.outputs.cache-hit != 'true'
-      run: |
-        nix copy\
-          --to 'file:///tmp/${{ inputs.local_cache_key }}?compression=zstd&parallel-compression=true'\
-          ${{ steps.build.outputs.out-path }}
     - name: Install + Push to Cachix
       shell: ${{ inputs.shell }}
       if: ${{ inputs.cachix_token != '' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,11 +124,11 @@ jobs:
             access-tokens = github.com=${{ env.GITHUB_TOKEN }}
             extra-substituters = https://openlane.cachix.org
             extra-trusted-public-keys = openlane.cachix.org-1:qqdwh+QMNGmZAuyeQJTH9ErW57OWSvdtuwfBKdS254E=
+      - uses: DeterminateSystems/magic-nix-cache-action@main
       - name: Build with Nix
         uses: ./.github/actions/build_nix
         with:
           nix_system: x86_64-linux
-          local_cache_key: derivation-${{ github.run_id }}
           cachix_cache: ${{ vars.CACHIX_CACHE || 'openlane' }}
           cachix_token: "${{ secrets.CACHIX_TOKEN }}"
           run_tests: "true"
@@ -151,11 +151,11 @@ jobs:
             access-tokens = github.com=${{ env.GITHUB_TOKEN }}
             extra-substituters = https://openlane.cachix.org
             extra-trusted-public-keys = openlane.cachix.org-1:qqdwh+QMNGmZAuyeQJTH9ErW57OWSvdtuwfBKdS254E=
+      - uses: DeterminateSystems/magic-nix-cache-action@main
       - name: Build with Nix
         uses: ./.github/actions/build_nix
         with:
           nix_system: aarch64-linux
-          local_cache_key: derivation-${{ github.run_id }}
           cachix_cache: ${{ vars.CACHIX_CACHE || 'openlane' }}
           cachix_token: "${{ secrets.CACHIX_TOKEN }}"
           run_tests: "true"
@@ -185,6 +185,7 @@ jobs:
             access-tokens = github.com=${{ env.GITHUB_TOKEN }}
             extra-substituters = https://openlane.cachix.org
             extra-trusted-public-keys = openlane.cachix.org-1:qqdwh+QMNGmZAuyeQJTH9ErW57OWSvdtuwfBKdS254E=
+      - uses: DeterminateSystems/magic-nix-cache-action@main
       # For some reason, GHA Macs are far more aggressively rate-limited with
       # Volare than Linux
       - name: Cache sky130 PDK
@@ -197,7 +198,6 @@ jobs:
         uses: ./.github/actions/build_nix
         with:
           nix_system: ${{ matrix.system.nix }}
-          local_cache_key: derivation-${{ github.run_id }}
           cachix_cache: ${{ vars.CACHIX_CACHE || 'openlane' }}
           cachix_token: "${{ secrets.CACHIX_TOKEN }}"
           shell: "zsh {0}"
@@ -232,11 +232,11 @@ jobs:
           fi
           echo "NIX_SYSTEM=$nix_system" >> $GITHUB_ENV
       - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@main
       - name: Build with Nix
         uses: ./.github/actions/build_nix
         with:
           nix_system: ${{ env.NIX_SYSTEM }}
-          local_cache_key: derivation-${{ github.run_id }}
           cachix_cache: ${{ vars.CACHIX_CACHE || 'openlane' }}
 
       - name: Build Docker Image
@@ -300,14 +300,12 @@ jobs:
         run: |
           git status || true
           tree .git || true
-
       - uses: DeterminateSystems/nix-installer-action@main
-
+      - uses: DeterminateSystems/magic-nix-cache-action@main
       - name: Build with Nix
         uses: ./.github/actions/build_nix
         with:
           nix_system: x86_64-linux
-          local_cache_key: derivation-${{ github.run_id }}
           cachix_cache: ${{ vars.CACHIX_CACHE || 'openlane' }}
 
       - name: Check Nix

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,16 +118,12 @@ jobs:
       - name: Set up GITHUB_TOKEN
         run: |
           echo "GITHUB_TOKEN=${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}" >> $GITHUB_ENV
-      - name: Install Nix
-        run: |
-          sh <(curl -L https://nixos.org/nix/install) --yes --daemon --nix-extra-conf-file /dev/stdin <<EXTRA_NIX_CONF
-          extra-experimental-features = nix-command flakes
-          extra-substituters = https://openlane.cachix.org
-          extra-trusted-public-keys = openlane.cachix.org-1:qqdwh+QMNGmZAuyeQJTH9ErW57OWSvdtuwfBKdS254E=
-          EXTRA_NIX_CONF
-
-          . '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh'
-          echo "PATH=$PATH" >> $GITHUB_ENV
+      - uses: DeterminateSystems/nix-installer-action@main
+        with:
+          extra-conf: |
+            access-tokens = github.com=${{ env.GITHUB_TOKEN }}
+            extra-substituters = https://openlane.cachix.org
+            extra-trusted-public-keys = openlane.cachix.org-1:qqdwh+QMNGmZAuyeQJTH9ErW57OWSvdtuwfBKdS254E=
       - name: Build with Nix
         uses: ./.github/actions/build_nix
         with:
@@ -149,7 +145,12 @@ jobs:
       - name: Set up GITHUB_TOKEN
         run: |
           echo "GITHUB_TOKEN=${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}" >> $GITHUB_ENV
-      - uses: DeterminateSystems/nix-installer-action@main # Using the DS Nix installer because it also sets up binfmt
+      - uses: DeterminateSystems/nix-installer-action@main
+        with:
+          extra-conf: |
+            access-tokens = github.com=${{ env.GITHUB_TOKEN }}
+            extra-substituters = https://openlane.cachix.org
+            extra-trusted-public-keys = openlane.cachix.org-1:qqdwh+QMNGmZAuyeQJTH9ErW57OWSvdtuwfBKdS254E=
       - name: Build with Nix
         uses: ./.github/actions/build_nix
         with:
@@ -178,17 +179,12 @@ jobs:
       - name: Set up GITHUB_TOKEN
         run: |
           echo "GITHUB_TOKEN=${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}" >> $GITHUB_ENV
-      - name: Install Nix
-        run: |
-          sh <(curl -L https://nixos.org/nix/install) --yes --nix-extra-conf-file /dev/stdin <<EXTRA_NIX_CONF
-          extra-experimental-features = nix-command flakes
-          extra-substituters = https://openlane.cachix.org
-          extra-trusted-public-keys = openlane.cachix.org-1:qqdwh+QMNGmZAuyeQJTH9ErW57OWSvdtuwfBKdS254E=
-          access-tokens = github.com=${{ env.GITHUB_TOKEN }}
-          EXTRA_NIX_CONF
-
-          . '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh'
-          echo "PATH=$PATH" >> $GITHUB_ENV
+      - uses: DeterminateSystems/nix-installer-action@main
+        with:
+          extra-conf: |
+            access-tokens = github.com=${{ env.GITHUB_TOKEN }}
+            extra-substituters = https://openlane.cachix.org
+            extra-trusted-public-keys = openlane.cachix.org-1:qqdwh+QMNGmZAuyeQJTH9ErW57OWSvdtuwfBKdS254E=
       # For some reason, GHA Macs are far more aggressively rate-limited with
       # Volare than Linux
       - name: Cache sky130 PDK

--- a/Readme.md
+++ b/Readme.md
@@ -68,7 +68,7 @@ timeline
   Signoff (Timing)
     : Parasitics Extraction / OpenROAD
     : Multi-corner Static Timing Analysis / OpenSTA
-    : Multi-corner Static Timing Analysis / PrimeTime (with proprietary plugin)
+    : SI-Enabled Multi-corner Static Timing Analysis / PrimeTime (with proprietary plugin)
   Signoff (Physical)
     : GDSII Stream-Out / Magic
     : GDSII Stream-Out / KLayout
@@ -159,7 +159,7 @@ If you use OpenLane in your research, please cite the following paper.
   doi={}}
 ```
 
-## License
+## License and Information
 
 [The Apache License, version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt).
 

--- a/Readme.md
+++ b/Readme.md
@@ -32,23 +32,52 @@ started. You can discuss OpenLane 2 in the
 channel of the
 [Efabless Open Source Silicon Slack](https://invite.skywater.tools).
 
-```python
-from openlane.flows import Flow
-
-Classic = Flow.factory.get("Classic")
-
-flow = Classic(
-    {
-        "PDK": "sky130A",
-        "DESIGN_NAME": "spm",
-        "VERILOG_FILES": ["./src/spm.v"],
-        "CLOCK_PORT": "clk",
-        "CLOCK_PERIOD": 10,
-    },
-    design_dir=".",
-)
-
-flow.start()
+```mermaid
+timeline
+  title The OpenLane Infrastructure
+  RTL to Netlist
+    : Linting / Verilator
+    : Power Distribution Network Hierarchy / Yosys
+    : Synthesis / Yosys
+    : Synthesis / Design Compiler (with proprietary plugin)
+    : Multi-corner Netlist STA / OpenSTA
+  Floorplanning
+    : Floorplan Initialization / OpenROAD
+    : Manual Macro Placement / OpenDB
+    : Tap/Endcap Insertion / OpenROAD
+    : PDN Generation / OpenROAD
+  Placement
+    : Pin Placement (from config file) / OpenROAD, OpenDB
+    : Pin Placement (Random/Matching/Annealing) / OpenROAD
+    : Pin Placement (from template DEF) / OpenDB
+    : Global Placement / OpenROAD
+    : Resizer Design Repair (Post-GPL) / OpenROAD
+    : Detailed Placement / OpenROAD
+  Clock Tree Synthesis
+    : Clock-Tree Synthesis / OpenROAD
+    : Resizer Timing Repair (Post-CTS) / OpenROAD
+  Routing
+    : Global Routing / OpenROAD
+    : Resizer Design Repair (Post-GRT) / OpenROAD
+    : Diode Insertion on Ports / OpenDB
+    : Heuristic Diode Insertion / OpenDB
+    : Antenna Repair / OpenROAD
+    : Resizer Timing Repair (Post-GRT) / OpenROAD
+    : Detailed Routing / OpenROAD
+    : Row Filling / OpenROAD
+  Signoff (Timing)
+    : Parasitics Extraction / OpenROAD
+    : Multi-corner Static Timing Analysis / OpenSTA
+    : Multi-corner Static Timing Analysis / PrimeTime (with proprietary plugin)
+  Signoff (Physical)
+    : GDSII Stream-Out / Magic
+    : GDSII Stream-Out / KLayout
+    : Magic vs. KLayout Stream XOR / KLayout
+    : Design Rule Checks / Magic
+    : Design Rule Checks / KLayout
+    : Spice Extraction / Magic
+    : Layout vs. Schematic / Netgen
+    : Equivalence Check (Alpha) / Yosys EQY
 ```
 
 ## Try it out
@@ -83,14 +112,17 @@ in the docs for more info.
 Do note you'll need to add `--dockerized` right after `openlane` in most CLI
 invocations.
 
-### Python-only Installation (Advanced)
+### Python-only Installation (Advanced, Not Recommended)
 
-You'll need to bring your own compiled utilities, but otherwise, simply install
-OpenLane as follows:
+**You'll need to bring your own compiled utilities**, but otherwise, simply
+install OpenLane as follows:
 
 ```sh
 python3 -m pip install --upgrade openlane
 ```
+
+Python-only installations are presently unsupported and entirely at your own
+risk.
 
 ## Usage
 

--- a/docs/source/getting_started/common/nix_installation/installation_linux.md
+++ b/docs/source/getting_started/common/nix_installation/installation_linux.md
@@ -14,6 +14,11 @@ If you're looking to build a virtual machine, we recommend [Ubuntu 22.04](https:
 
 ## Installing Nix
 
+```{warning}
+Do **not** install Nix using `apt`. The version of Nix offered by `apt` is more
+often than not severely out-of-date and may cause issues.
+```
+
 You will need `curl` to install Nix.
 
 To install curl on Ubuntu, simply type in the following in your terminal:
@@ -25,11 +30,10 @@ $ sudo apt-get install -y curl
 After that, simply run this command:
 
 ```console
-$ sh <(curl -L https://nixos.org/nix/install) --yes --daemon --nix-extra-conf-file /dev/stdin <<EXTRA_NIX_CONF
-extra-experimental-features = nix-command flakes
-extra-substituters = https://openlane.cachix.org
-extra-trusted-public-keys = openlane.cachix.org-1:qqdwh+QMNGmZAuyeQJTH9ErW57OWSvdtuwfBKdS254E=
-EXTRA_NIX_CONF
+$ curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install --no-confirm --extra-conf "
+    extra-substituters = https://openlane.cachix.org
+    extra-trusted-public-keys = openlane.cachix.org-1:qqdwh+QMNGmZAuyeQJTH9ErW57OWSvdtuwfBKdS254E=
+"
 ```
 
 Enter your password if prompted. This should take around 5 minutes.

--- a/docs/source/getting_started/common/nix_installation/installation_macos.md
+++ b/docs/source/getting_started/common/nix_installation/installation_macos.md
@@ -15,11 +15,10 @@
 Simply run this (entire) command in `Terminal.app`:
 
 ```console
-$ sh <(curl -L https://nixos.org/nix/install) --yes --nix-extra-conf-file /dev/stdin <<EXTRA_NIX_CONF
-extra-experimental-features = nix-command flakes
-extra-substituters = https://openlane.cachix.org
-extra-trusted-public-keys = openlane.cachix.org-1:qqdwh+QMNGmZAuyeQJTH9ErW57OWSvdtuwfBKdS254E=
-EXTRA_NIX_CONF
+$ curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install --no-confirm --extra-conf "
+    extra-substituters = https://openlane.cachix.org
+    extra-trusted-public-keys = openlane.cachix.org-1:qqdwh+QMNGmZAuyeQJTH9ErW57OWSvdtuwfBKdS254E=
+"
 ```
 
 Enter your password if prompted. This should take around 5 minutes.

--- a/docs/source/getting_started/common/nix_installation/installation_win.md
+++ b/docs/source/getting_started/common/nix_installation/installation_win.md
@@ -45,6 +45,11 @@ Windows 10 is up-to-date.
 
 ## Installing Nix
 
+```{warning}
+Do **not** install Nix using `apt`. The version of Nix offered by `apt` is more
+often than not severely out-of-date and may cause issues.
+```
+
 To install Nix, you first need to install `curl`:
 
 ```console
@@ -54,11 +59,10 @@ $ sudo apt-get install -y curl
 Then install Nix by running the following command:
 
 ```console 
-$ sh <(curl -L https://nixos.org/nix/install) --yes --daemon --nix-extra-conf-file /dev/stdin <<EXTRA_NIX_CONF
-extra-experimental-features = nix-command flakes
-extra-substituters = https://openlane.cachix.org
-extra-trusted-public-keys = openlane.cachix.org-1:qqdwh+QMNGmZAuyeQJTH9ErW57OWSvdtuwfBKdS254E=
-EXTRA_NIX_CONF
+$ curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install --no-confirm --extra-conf "
+    extra-substituters = https://openlane.cachix.org
+    extra-trusted-public-keys = openlane.cachix.org-1:qqdwh+QMNGmZAuyeQJTH9ErW57OWSvdtuwfBKdS254E=
+"
 ```
 
 Enter your password if prompted. This should take around 5 minutes.

--- a/flake.lock
+++ b/flake.lock
@@ -162,11 +162,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1719908402,
-        "narHash": "sha256-l6GtRmdLVqu8mS0YvOoHrc62rneFLfABCMJopTalon8=",
+        "lastModified": 1724178650,
+        "narHash": "sha256-p+Li/z3l7ShRSIKUrxVK+7uGhSvqPE7jOW4FA4k3SIw=",
         "owner": "efabless",
         "repo": "volare",
-        "rev": "0dea0d1acece68aafbf6263c6e2db7c7a58bf1b7",
+        "rev": "0090420799258d29adca54c8951d38bb8b605aeb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Documentation
* Installation documents now use the less-brittle Determinate Systems Nix installer, as well as adding warnings about the `apt` version of Nix.
* Added an OpenROAD Flow Scripts-inspired Diagram to the Readme.

## Testing
* CI now uses Determinate Systems Nix Installer for all Nix installations as well as the Magic Nix Cache Action instead of the nonfunctional attempt at local file-based substituters