### PR TITLE
Bundle stable OpenSTA alongside OpenROAD's version

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,28 @@
 ## Documentation
 -->
 
+# 2.1.3
+
+## Tool Updates
+
+* Bundled an downgraded OpenSTA bundled with OpenLane to work around critical
+  bug for hierarchical static timing analysis:
+  https://github.com/parallaxsw/OpenSTA/issues/82
+  * Version of OpenSTA linked against OpenROAD unchanged.
+
+## Testing
+
+* CI now uses DeterminateSystems Nix Installer for all Nix installations as well
+  as the Magic Nix Cache Action instead of the nonfunctional attempt at local
+  file-based substituters
+
+## Documentation
+
+* Installation documents now use the less-brittle Determinate Systems Nix
+  installer, as well as adding warnings about the `apt` version of Nix.
+
+* Added an OpenROAD Flow Scripts-inspired Diagram to the Readme.
+
 # 2.1.2
 
 ## Steps

--- a/default.nix
+++ b/default.nix
@@ -23,7 +23,7 @@
   libparse,
   magic-vlsi,
   netgen,
-  opensta,
+  opensta-stable,
   openroad,
   ruby,
   surelog,
@@ -77,7 +77,7 @@
           yosys-f4pga-sdc
         ]
         ++ lib.optionals (system == "x86_64-linux") [yosys-ghdl]))
-      opensta
+      opensta-stable
       openroad
       klayout
       netgen

--- a/flake.nix
+++ b/flake.nix
@@ -69,6 +69,10 @@
             });
             colab-env = callPackage ./nix/colab-env.nix {};
             opensta = callPackage ./nix/opensta.nix {};
+            opensta-stable = callPackage ./nix/opensta.nix {
+              rev = "cc9eb1f12a0d5030aebc1f1428e4300480e30b40";
+              sha256 = "sha256-/ShPD4xWq3lkN0Z3uONKm7i9eqbT+IU41UF7yIvDJy4=";
+            };
             openroad-abc = callPackage ./nix/openroad-abc.nix {};
             openroad = callPythonPackage ./nix/openroad.nix {};
             openlane = callPythonPackage ./default.nix {};

--- a/nix/opensta.nix
+++ b/nix/opensta.nix
@@ -78,6 +78,7 @@ clangStdenv.mkDerivation (finalAttrs: {
   meta = with lib; {
     description = "Gate-level static timing verifier";
     homepage = "https://parallaxsw.com";
+    mainProgram = "sta";
     license = licenses.gpl3Plus;
     platforms = platforms.darwin ++ platforms.linux;
   };

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openlane"
-version = "2.1.2"
+version = "2.1.3"
 description = "An infrastructure for implementing chip design flows"
 authors = ["Efabless Corporation and Contributors <donn@efabless.com>"]
 readme = "Readme.md"


### PR DESCRIPTION
## Tool Updates

* Bundled a downgraded OpenSTA bundled with OpenLane to work around critical bug for hierarchical static timing analysis: https://github.com/parallaxsw/OpenSTA/issues/82
  * Version of OpenSTA linked against OpenROAD unchanged.