### PR TITLE
Fix regression in `2.1.1`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,23 @@
 ## Documentation
 -->
 
+# 2.1.5
+
+## Steps
+
+* `Odb.SetPowerConnections`
+
+  * Fixed an issue introduced in `2.1.1` where modules that are defined as part
+    of hierarchical netlists would be considered macros and then cause a crash
+    when they are inevitably not found in the design database.
+    * Explicitly mention that macros that are not on the top level will not be
+      connected, and emit warnings if a hierarchical netlist is detected.
+
+## Documentation
+
+* Updated macro documentation to further clarify how instances should be named
+  and how names should be added to the configuration.
+
 # 2.1.4
 
 ## Steps
@@ -27,7 +44,7 @@
     regardless the information in the SDC file.
   * For backwards compatibility, `STAPrePNR` unsets all propagated clocks and
     the rest set all propagated clocks IF the SDC file lacks the strings
-    `set_propagated_clock` or `unset_propagated_clock`.    
+    `set_propagated_clock` or `unset_propagated_clock`.
 
 # 2.1.3
 

--- a/docs/source/usage/using_macros.md
+++ b/docs/source/usage/using_macros.md
@@ -154,7 +154,7 @@ would be declared as:
   }
 ```
 
-```{admonition} On Instance Names
+````{admonition} On Instance Names
 :class: tip
 
 Instance names should match the name as instantiated in Verilog, i.e.,
@@ -163,7 +163,53 @@ without escaping any characters for layout formats.
 For example, if you instantiate an array of macros `spm spm_inst[1:0]`,
 the first instance's name should be `spm_inst[0]`, not
 `spm_inst\[0\]` or similar.
+
+---
+
+If your macros are within other instances, the names get a bit more complicated
+depending on whether you flatten the hierarchy during synthesis or not. It is
+the designer's responsibility to use either notation in the Instances dictionary
+depending on which hierarchy mode is utilized. 
+
+**Hierarchy flattened during Synthesis (default, recommended)**
+
+When flattening the hierarchy, Yosys will rename instances to use the dot
+notation, i.e, the name of an instance inside another instance will be
+`instance_a.instance_b`. Note that they are the names of instances and not
+the names of modules.
+
+**Hierarchy maintainted during Synthesis**
+
+Using macros with hierarchy is maintained during Synthesis is
+**currently unsupported** in OpenLane, as the netlist is flattened upon moving
+into OpenROAD as its hierarchical support is rather experimental. This will be
+remedied in a future update to OpenLane.
+
+In the meantime, if you do choose to keep the hierarchy after Synthesis
+regardless by using the attribute `(* keep_hierarchy = "TRUE" *)`, you're on
+your own, but here are a couple tips.
+* Naming will fall upon OpenROAD, which use the `/` notation regardless of your
+  technology LEF's divider characters property, i.e., `instance_a/instance_b`.
+  Note once again that are the names of instances and not the names of modules.
+* The power and ground pins of the macro must match that of the standard cell
+  library as `Odb.SetPowerConnections` won't work for these macros.
+  
+**Please do not do this:**
+
+Please do not use any of these characters in instance names by using the `\`
+prefix, as the example below shows:
+
+* `/` 
+* `[]`
+* `:`
+
+Using these is considered **undefined behavior** and the flow will likely crash
+because of assumptions about the hierarchy involving these characters.
+
+```verilog
+CellType \instance/name (…);
 ```
+````
 
 ## STA
 

--- a/openlane/scripts/odbpy/power_utils.py
+++ b/openlane/scripts/odbpy/power_utils.py
@@ -33,7 +33,7 @@ class Design(object):
     @dataclass
     class Instance:
         name: str
-        module: str
+        module_name: str
         power_connections: Dict[str, str]
         ground_connections: Dict[str, str]
 
@@ -41,15 +41,20 @@ class Design(object):
         self.reader = reader
         self.design_name = reader.block.getName()
         self.yosys_dict = yosys_dict
-        self.yosys_design_object = yosys_dict["modules"][self.design_name]
 
         self.pins_by_module_name: Dict[str, Dict[str, odb.dbMTerm]] = {}
-        self.verilog_net_name_by_bit: Dict[int, str] = functools.reduce(
-            lambda a, b: {**a, **{bit: b[0] for bit in b[1]["bits"]}},
-            self.yosys_design_object["netnames"].items(),
-            {},
-        )
+        self.verilog_net_names_by_bit_by_module: Dict[str, Dict[int, str]] = {}
         self.nets_by_net_name = {net.getName(): net for net in reader.block.getNets()}
+
+    def get_verilog_net_name_by_bit(self, top_module: str, target_bit: int):
+        yosys_design_object = self.yosys_dict["modules"][top_module]
+        if top_module not in self.verilog_net_names_by_bit_by_module:
+            self.verilog_net_names_by_bit_by_module[top_module] = functools.reduce(
+                lambda a, b: {**a, **{bit: b[0] for bit in b[1]["bits"]}},
+                yosys_design_object["netnames"].items(),
+                {},
+            )
+        return self.verilog_net_names_by_bit_by_module[top_module][target_bit]
 
     def get_pins(self, module_name: str) -> Dict[str, odb.dbMTerm]:
         if module_name not in self.pins_by_module_name:
@@ -83,10 +88,17 @@ class Design(object):
 
         return module_pins[pin_name].getSigType() == "GROUND"
 
-    def extract_pg_pins(self, cell_name: str) -> dict:
-        cells = self.yosys_design_object["cells"]
-        module = cells[cell_name]["type"]
-        master = self.reader.db.findMaster(module)
+    def extract_pg_pins(self, top_module: str, cell_name: str) -> dict:
+        yosys_design_object = self.yosys_dict["modules"][top_module]
+        cells = yosys_design_object["cells"]
+        module_name = cells[cell_name]["type"]
+        master = self.reader.db.findMaster(module_name)
+        if master is None:
+            print(
+                f"[ERROR] Could not find master for cell type '{module_name}' in the database."
+            )
+            exit(-1)
+
         lef_pg_pins = []
         for pin in master.getMTerms():
             if pin.getSigType() in ["POWER", "GROUND"]:
@@ -102,32 +114,53 @@ class Design(object):
             connection_bits = connections[pin_name]
             if len(connection_bits) != 1:
                 print(
-                    f"[ERROR] Unexpectedly found more than one bit connected to {sigtype} pin {module}/{pin_name}."
+                    f"[ERROR] Unexpectedly found more than one bit connected to {sigtype} pin {module_name}/{pin_name}."
                 )
                 exit(-1)
             connection_bit = connection_bits[0]
-            connected_to_v = self.verilog_net_name_by_bit[connection_bit]
+            connected_to_v = self.get_verilog_net_name_by_bit(
+                top_module,
+                connection_bit,
+            )
             (power_pins if sigtype == "POWER" else ground_pins)[
                 pin_name
             ] = connected_to_v
 
         return power_pins, ground_pins
 
-    def extract_instances(self) -> List["Design.Instance"]:
+    def extract_instances(
+        self,
+        top_module: str,
+        prefix: str = "",
+    ) -> List["Design.Instance"]:
+        yosys_design_object = self.yosys_dict["modules"][top_module]
         instances = []
-        cells = self.yosys_design_object["cells"]
+        cells = yosys_design_object["cells"]
         for cell_name in cells.keys():
-            module = cells[cell_name]["type"]
-            if module.startswith("$"):
+            module_name = cells[cell_name]["type"]
+            if module_name.startswith("$"):
                 # yosys primitive
                 continue
-            power_pins, ground_pins = self.extract_pg_pins(cell_name)
+            if module_name in self.yosys_dict["modules"]:
+                print(
+                    f"[WARNING] Macros inside hierarchical netlists are not currently supported in OpenLane: skipping submodule '{cell_name}' of type '{module_name}'."
+                )
+                continue
+                # sub_instances = self.extract_instances(
+                #     self.yosys_dict["modules"][module_name],
+                #     prefix=prefix + f"{cell_name}/",
+                # )
+                # instances += sub_instances
+            power_pins, ground_pins = self.extract_pg_pins(
+                top_module,
+                cell_name,
+            )
             instances.append(
                 Design.Instance(
-                    name=cell_name,
+                    name=prefix + cell_name,
                     ground_connections=ground_pins,
                     power_connections=power_pins,
-                    module=module,
+                    module_name=module_name,
                 )
             )
 
@@ -244,7 +277,7 @@ def set_power_connections(input_json, reader: OdbReader):
     yosys_dict = json.loads(design_str)
 
     design = Design(reader, yosys_dict)
-    macro_instances = design.extract_instances()
+    macro_instances = design.extract_instances(design.design_name)
     for instance in macro_instances:
         for pin in instance.power_connections.keys():
             net_name = instance.power_connections[pin]

--- a/openlane/scripts/odbpy/reader.py
+++ b/openlane/scripts/odbpy/reader.py
@@ -86,8 +86,8 @@ class OdbReader(object):
             self.instances = self.block.getInsts()
 
         busbitchars = re.escape("[]")  # TODO: Get alternatives from LEF parser
-        dividerchar = re.escape("/")  # TODO: Get alternatives from LEF parser
-        self.escape_verilog_rx = re.compile(rf"([{dividerchar + busbitchars}])")
+        # dividerchar = re.escape("/")  # TODO: Get alternatives from LEF parser
+        self.escape_verilog_rx = re.compile(rf"([{busbitchars}])")
 
     def add_lef(self, new_lef):
         self.ord_tech.readLef(new_lef)

--- a/openlane/steps/odb.py
+++ b/openlane/steps/odb.py
@@ -265,8 +265,12 @@ class ApplyDEFTemplate(OdbpyStep):
 @Step.factory.register()
 class SetPowerConnections(OdbpyStep):
     """
-    Uses JSON netlist and module information in Odb to add global power connections
-    for macros in a design.
+    Uses JSON netlist and module information in Odb to add global power
+    connections for macros at the top level of a design.
+
+    If the JSON netlist is hierarchical (e.g. by using a keep hierarchy
+    attribute) this Step emits a warning and does not attempt to connect any
+    macros instantiated within submodules.
     """
 
     id = "Odb.SetPowerConnections"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openlane"
-version = "2.1.4"
+version = "2.1.5"
 description = "An infrastructure for implementing chip design flows"
 authors = ["Efabless Corporation and Contributors <donn@efabless.com>"]
 readme = "Readme.md"

--- a/test/steps/excluded_step_tests
+++ b/test/steps/excluded_step_tests
@@ -1,1 +1,0 @@
-odb.setpowerconnections/003-fail_mismatched_view


### PR DESCRIPTION
* `Odb.SetPowerConnections`

  * Fixed an issue introduced in `2.1.1` where modules that are defined as part of hierarchical netlists would be considered macros and then cause a crash when they are inevitably not found in the design database. * Explicitly mention that macros that are not on the top level will not be connected, and emit warnings if a hierarchical netlist is detected.

## Documentation

* Updated macro documentation to further clarify how instances should be named and how names should be added to the configuration.