### PR TITLE
Fix arguments passed to Yosys hilomap

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,14 @@
 ## Documentation
 -->
 
+# 2.1.6
+
+## Steps
+
+* `Yosys.Synthesis`
+  
+  * Fixed bug where `hilomap` command was invoked incorrectly (thanks @htfab!)
+
 # 2.1.5
 
 ## Steps

--- a/openlane/scripts/yosys/synthesize.tcl
+++ b/openlane/scripts/yosys/synthesize.tcl
@@ -180,7 +180,7 @@ proc run_strategy {output script strategy_name {postfix_with_strategy 0}} {
 
     setundef -zero
 
-    hilomap -hicell $::env(SYNTH_TIEHI_CELL) -locell $::env(SYNTH_TIELO_CELL)
+    hilomap -hicell {*}[split $::env(SYNTH_TIEHI_CELL) "/"] -locell {*}[split $::env(SYNTH_TIELO_CELL) "/"]
 
     if { $::env(SYNTH_SPLITNETS) } {
         splitnets

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openlane"
-version = "2.1.5"
+version = "2.1.6"
 description = "An infrastructure for implementing chip design flows"
 authors = ["Efabless Corporation and Contributors <donn@efabless.com>"]
 readme = "Readme.md"


### PR DESCRIPTION
In the Yosys synthesis script the `hilomap` command used for techmapping constant drivers is called with the wrong arguments. For instance, for sky130 it runs

`hilomap -hicell sky130_fd_sc_hd__conb_1/HI -locell sky130_fd_sc_hd__conb_1/LO`

instead of

`hilomap -hicell sky130_fd_sc_hd__conb_1 HI -locell sky130_fd_sc_hd__conb_1 LO`

This results in the step being skipped and some warnings:

```
56. Executing HILOMAP pass (mapping to constant drivers).
Warning: Selection "sky130_fd_sc_hd__conb_1" did not match any module.
Warning: Selection "LO" did not match any object.
```

This is a regression from OpenLane 1.