### PR TITLE
Fix Odb.RemoveRoutingObstructions failing with non-integer coordinates

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,16 @@
 ## Documentation
 -->
 
+# 2.1.7
+
+## Steps
+
+* `Odb.Remove*Obstructions`
+
+  * Rework obstruction matching code to not use IEEE 754 in any capacity
+  * Fixed bug where non-integral obstructions would not be matched correctly
+    (thanks @urish!)
+
 # 2.1.6
 
 ## Steps

--- a/openlane/scripts/odbpy/defutil.py
+++ b/openlane/scripts/odbpy/defutil.py
@@ -531,7 +531,7 @@ def remove_obstructions(reader, input_lefs, obstructions):
     dbu = reader.tech.getDbUnitsPerMicron()
 
     def to_microns(x):
-        return int(x / dbu)
+        return round(x / dbu, 3)
 
     for odb_obstruction in reader.block.getObstructions():
         bbox = odb_obstruction.getBBox()

--- a/openlane/scripts/odbpy/defutil.py
+++ b/openlane/scripts/odbpy/defutil.py
@@ -17,6 +17,7 @@ import odb
 import os
 import re
 import sys
+from decimal import Decimal
 
 from reader import click_odb, click
 from typing import Tuple, List
@@ -456,7 +457,7 @@ def replace_instance_prefixes(original_prefix, new_prefix, reader):
 cli.add_command(replace_instance_prefixes)
 
 
-def parse_obstructions(obstructions):
+def parse_obstructions(obstructions) -> List[Tuple[str, List[int]]]:
     RE_NUMBER = r"[\-]?[0-9]+(\.[0-9]+)?"
     RE_OBS = (
         r"(?P<layer>\S+)\s+"
@@ -483,7 +484,7 @@ def parse_obstructions(obstructions):
             sys.exit(FORMAT_ERROR)
         else:
             layer = m.group("layer")
-            bbox = [float(x) for x in m.group("bbox").split()]
+            bbox = [Decimal(x) for x in m.group("bbox").split()]
             obs_list.append((layer, bbox))
 
     return obs_list
@@ -526,12 +527,8 @@ cli.add_command(add_obstructions)
 )
 @click_odb
 def remove_obstructions(reader, input_lefs, obstructions):
-    obs_list = parse_obstructions(obstructions)
+    dbu: int = reader.tech.getDbUnitsPerMicron()
     existing_obstructions: List[Tuple[str, List[int], odb.dbObstruction]] = []
-    dbu = reader.tech.getDbUnitsPerMicron()
-
-    def to_microns(x):
-        return round(x / dbu, 3)
 
     for odb_obstruction in reader.block.getObstructions():
         bbox = odb_obstruction.getBBox()
@@ -539,28 +536,28 @@ def remove_obstructions(reader, input_lefs, obstructions):
             (
                 bbox.getTechLayer().getName(),
                 [
-                    to_microns(bbox.xMin()),
-                    to_microns(bbox.yMin()),
-                    to_microns(bbox.xMax()),
-                    to_microns(bbox.yMax()),
+                    bbox.xMin(),
+                    bbox.yMin(),
+                    bbox.xMax(),
+                    bbox.yMax(),
                 ],
                 odb_obstruction,
             )
         )
 
-    for obs in obs_list:
-        layer = obs[0]
-        bbox = obs[1]
-        bbox = [int(x * dbu) for x in bbox]
+    for obs in parse_obstructions(obstructions):
+        layer, bbox = obs
+        bbox = [int(x * dbu) for x in bbox]  # To dbus
         found = False
         if reader.tech.findLayer(layer) is None:
             print(f"[ERROR] layer {layer} doesn't exist.", file=sys.stderr)
             sys.exit(METAL_LAYER_ERROR)
         for odb_obstruction in existing_obstructions:
-            if odb_obstruction[0:2] == obs:
+            odb_layer, odb_bbox, odb_obj = odb_obstruction
+            if (odb_layer, odb_bbox) == (layer, bbox):
                 print(f"Removing obstruction on {layer} at {bbox} (DBU)…")
                 found = True
-                odb.dbObstruction_destroy(odb_obstruction[2])
+                odb.dbObstruction_destroy(odb_obj)
             if found:
                 break
         if not found:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openlane"
-version = "2.1.6"
+version = "2.1.7"
 description = "An infrastructure for implementing chip design flows"
 authors = ["Efabless Corporation and Contributors <donn@efabless.com>"]
 readme = "Readme.md"


### PR DESCRIPTION
When specifying non integer coordinates in `ROUTING_OBSTRUCTIONS`, the Odb.RemoveRoutingObstructions would fail as it would truncate the decimal part before trying to match the coordinate.

For example, the following config would fail on any project (due to 16.5 appearing in the coordinate list):

```json
  "ROUTING_OBSTRUCTIONS": [
    "met1 10 10 20 16.5"
  ],
```