### PR TITLE
Fix Zero-Slack Paths Being Counted As Violations

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -17,7 +17,7 @@
 
 ## Steps
 
-* `OpenROAD.MultiCornerSTA`:
+* `OpenROAD.MultiCornerSTA`
 
   * Fix a bug in STA metrics where paths with exactly zero slack are counted as violations
  

--- a/Changelog.md
+++ b/Changelog.md
@@ -13,7 +13,14 @@
 ## API Breaks
 ## Documentation
 -->
+# 2.1.8
 
+## Steps
+
+* `OpenROAD.MultiCornerSTA`:
+
+  * Fix a bug in STA metrics where paths with exactly zero slack are counted as violations
+ 
 # 2.1.7
 
 ## Steps

--- a/Changelog.md
+++ b/Changelog.md
@@ -13,14 +13,16 @@
 ## API Breaks
 ## Documentation
 -->
+
 # 2.1.8
 
 ## Steps
 
-* `OpenROAD.MultiCornerSTA`
+* `OpenROAD.STA*PnR`
 
-  * Fix a bug in STA metrics where paths with exactly zero slack are counted as violations
- 
+  * Fixed a bug in STA metrics where paths with exactly zero slack are counted
+    as violations
+
 # 2.1.7
 
 ## Steps
@@ -36,7 +38,7 @@
 ## Steps
 
 * `Yosys.Synthesis`
-  
+
   * Fixed bug where `hilomap` command was invoked incorrectly (thanks @htfab!)
 
 # 2.1.5

--- a/openlane/scripts/openroad/sta/corner.tcl
+++ b/openlane/scripts/openroad/sta/corner.tcl
@@ -265,6 +265,11 @@ foreach path $hold_violating_paths {
     set start_pin [get_property $path startpoint]
     set end_pin [get_property $path endpoint]
     set kind "[get_path_kind $start_pin $end_pin]"
+    set slack [get_property $path slack]
+
+    if { $slack >= 0 } {
+        continue
+    }
 
     incr total_hold_vios
     if { "$kind" == "reg-reg" } {
@@ -279,6 +284,11 @@ foreach path $hold_paths {
     set start_pin [get_property $path startpoint]
     set end_pin [get_property $path endpoint]
     set kind "[get_path_kind $start_pin $end_pin]"
+    set slack [get_property $path slack]
+
+    if { $slack >= 0 } {
+        continue
+    }
     if { "$kind" == "reg-reg" } {
         set slack [get_property $path slack]
 
@@ -293,6 +303,11 @@ foreach path $setup_violating_paths {
     set start_pin [get_property $path startpoint]
     set end_pin [get_property $path endpoint]
     set kind "[get_path_kind $start_pin $end_pin]"
+    set slack [get_property $path slack]
+
+    if { $slack >= 0 } {
+        continue
+    }
 
     incr total_setup_vios
     if { "$kind" == "reg-reg" } {
@@ -307,6 +322,11 @@ foreach path $setup_paths {
     set start_pin [get_property $path startpoint]
     set end_pin [get_property $path endpoint]
     set kind "[get_path_kind $start_pin $end_pin]"
+    set slack [get_property $path slack]
+
+    if { $slack >= 0 } {
+        continue
+    }
 
     if { "$kind" == "reg-reg" } {
         set slack [get_property $path slack]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openlane"
-version = "2.1.7"
+version = "2.1.8"
 description = "An infrastructure for implementing chip design flows"
 authors = ["Efabless Corporation and Contributors <donn@efabless.com>"]
 readme = "Readme.md"


### PR DESCRIPTION
* `OpenROAD.STA*PnR`:
  * Fixed a bug in STA metrics where paths with exactly zero slack are counted as violations

# Testing
* Added a test case for #505

---
Depends on https://github.com/efabless/openlane2-step-unit-tests/pull/37
Fixes #505 