### PR TITLE
Fix Table Being Printed to File With Wrong Width

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,20 @@
 ## Documentation
 -->
 
+# 2.1.9
+
+## Steps
+
+* `OpenROAD.CheckAntennas`
+  * Fixed table being printed to file with wrong width
+* `OpenROAD.STA*PnR`
+  * Fixed table being printed to file with wrong width
+
+## Flows
+
+* `SynthesisExploration`
+  * Fixed table being printed to file with wrong width
+
 # 2.1.8
 
 ## Steps

--- a/openlane/flows/synth_explore.py
+++ b/openlane/flows/synth_explore.py
@@ -163,9 +163,11 @@ class SynthesisExploration(Flow):
 
         console.print(table)
         assert self.run_dir is not None
-        with open(os.path.join(self.run_dir, "summary.rpt"), "w") as f:
-            table.width = 160
-            rich.print(table, file=f)
+        file_console = rich.console.Console(
+            file=open(os.path.join(self.run_dir, "summary.rpt"), "w", encoding="utf8"),
+            width=160,
+        )
+        file_console.print(table)
 
         success("Flow complete.")
         return (initial_state, step_list)

--- a/openlane/steps/openroad.py
+++ b/openlane/steps/openroad.py
@@ -37,6 +37,7 @@ from typing import (
     Union,
 )
 
+
 import yaml
 import rich
 import rich.table
@@ -686,9 +687,11 @@ class MultiCornerSTA(OpenSTAStep):
 
         if not options.get_condensed_mode():
             console.print(table)
-        with open(os.path.join(self.step_dir, "summary.rpt"), "w") as f:
-            table.width = 160
-            rich.print(table, file=f)
+        file_console = rich.console.Console(
+            file=open(os.path.join(self.step_dir, "summary.rpt"), "w", encoding="utf8"),
+            width=160,
+        )
+        file_console.print(table)
 
         return {}, metric_updates_with_aggregates
 
@@ -1482,9 +1485,10 @@ class CheckAntennas(OpenROADStep):
 
         if not options.get_condensed_mode() and len(violations):
             console.print(table)
-        with open(output_file, "w") as f:
-            table.width = 80
-            rich.print(table, file=f)
+        file_console = rich.console.Console(
+            file=open(output_file, "w", encoding="utf8"), width=160
+        )
+        file_console.print(table)
 
     def __get_antenna_nets(self, report: io.TextIOWrapper) -> int:
         pattern = re.compile(r"Net:\s*(\w+)")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openlane"
-version = "2.1.8"
+version = "2.1.9"
 description = "An infrastructure for implementing chip design flows"
 authors = ["Efabless Corporation and Contributors <donn@efabless.com>"]
 readme = "Readme.md"


### PR DESCRIPTION
## Steps

* `OpenROAD.CheckAntennas`
  * Fixed table being printed to file with wrong width
* `OpenROAD.STA*PnR`
  *  Fixed table being printed to file with wrong width

## Flows

* `SynthesisExploration`
  * Fixed table being printed to file with wrong width