### PR TITLE
bugfix: fix wrong reported value for timing__*_r2r__ws__corner

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -15,11 +15,12 @@
 -->
 
 # 2.1.11
+
 ## Misc. Enhancements/Bugfixes
 
 * `OpenROAD.STA*PnR`
 
-  * Fix wrong reported value of `timing__*_r2r__ws__corner` metrics
+  * Fixed `timing__*_r2r__ws__corner` metrics reporting the wrong value
 
 # 2.1.10
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,13 @@
 ## Documentation
 -->
 
+# 2.1.11
+## Misc. Enhancements/Bugfixes
+
+* `OpenROAD.STA*PnR`
+
+  * Fix wrong reported value of `timing__*_r2r__ws__corner` metrics
+
 # 2.1.10
 
 ## Misc. Enhancements/Bugfixes

--- a/Changelog.md
+++ b/Changelog.md
@@ -16,7 +16,7 @@
 
 # 2.1.11
 
-## Misc. Enhancements/Bugfixes
+## Steps
 
 * `OpenROAD.STA*PnR`
 

--- a/openlane/scripts/openroad/sta/corner.tcl
+++ b/openlane/scripts/openroad/sta/corner.tcl
@@ -286,9 +286,6 @@ foreach path $hold_paths {
     set kind "[get_path_kind $start_pin $end_pin]"
     set slack [get_property $path slack]
 
-    if { $slack >= 0 } {
-        continue
-    }
     if { "$kind" == "reg-reg" } {
         set slack [get_property $path slack]
 
@@ -323,10 +320,6 @@ foreach path $setup_paths {
     set end_pin [get_property $path endpoint]
     set kind "[get_path_kind $start_pin $end_pin]"
     set slack [get_property $path slack]
-
-    if { $slack >= 0 } {
-        continue
-    }
 
     if { "$kind" == "reg-reg" } {
         set slack [get_property $path slack]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openlane"
-version = "2.1.10"
+version = "2.1.11"
 description = "An infrastructure for implementing chip design flows"
 authors = ["Efabless Corporation and Contributors <donn@efabless.com>"]
 readme = "Readme.md"


### PR DESCRIPTION
* `OpenROAD.STA*PnR`

  * Fixed `timing__*_r2r__ws__corner` metrics reporting the wrong value
  
---
When getting ws (worst slack), the flow shouldn't skip positive slacks. 