### PR TITLE
bugfix: odb steps dropping PYTHONPATH

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,18 @@
 ## Documentation
 -->
 
+# 2.2.2
+
+## Steps
+
+* `Odb.*`
+  * Fixed OpenROAD dropping user-set `PYTHONPATH` values.
+  
+## Tool Updates
+
+* Use `NIX_PYTHONPATH` instead of `PYTHONPATH` in Docker and devshells
+  to avoid collisions with user-set `PYTHONPATH` variables.
+
 # 2.2.1
 
 This patch has no functional changes to OpenLane proper.

--- a/nix/create-shell.nix
+++ b/nix/create-shell.nix
@@ -59,7 +59,7 @@ in
     devshell.packages = packages;
     env = [
       {
-        name = "PYTHONPATH";
+        name = "NIX_PYTHONPATH";
         value = "${openlane-env-sitepackages}";
       }
     ];

--- a/nix/docker.nix
+++ b/nix/docker.nix
@@ -72,7 +72,7 @@ in
       "LC_ALL=C.UTF-8"
       "LC_CTYPE=C.UTF-8"
       "EDITOR=nvim"
-      "PYTHONPATH=${openlane-env-sitepackages}"
+      "NIX_PYTHONPATH=${openlane-env-sitepackages}"
       "TMPDIR=/tmp"
     ];
     image-config-extra-path = [

--- a/openlane/steps/odb.py
+++ b/openlane/steps/odb.py
@@ -83,7 +83,9 @@ class OdbpyStep(Step):
             str(state_in[DesignFormat.ODB]),
         ]
 
-        env["PYTHONPATH"] = os.path.join(get_script_dir(), "odbpy")
+        env["PYTHONPATH"] = (
+            f'{os.path.join(get_script_dir(), "odbpy")}:{env.get("PYTHONPATH")}'
+        )
 
         subprocess_result = self.run_subprocess(
             command,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openlane"
-version = "2.2.1"
+version = "2.2.2"
 description = "An infrastructure for implementing chip design flows"
 authors = ["Efabless Corporation and Contributors <donn@efabless.com>"]
 readme = "Readme.md"


### PR DESCRIPTION
* `Odb.*`
  * Fixed OpenROAD dropping user-set `PYTHONPATH` values.

## Tool Updates

* Use `NIX_PYTHONPATH` instead of `PYTHONPATH` in Docker and devshells
  to avoid collisions with user-set `PYTHONPATH` variables.