### PR TITLE
bugfix: Register OpenROAD.WriteViews in step factory

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -13,6 +13,13 @@
 ## API Breaks
 ## Documentation
 -->
+# 2.2.6
+
+## Steps
+
+* `OpenROAD.WriteViews`
+
+  * Allowed step to be used in flows.
 
 # 2.2.5
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -19,7 +19,7 @@
 
 * `OpenROAD.WriteViews`
 
-  * Allowed step to be used in flows.
+  * Fixed step not being registered to factory object.
 
 # 2.2.6
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -13,7 +13,7 @@
 ## API Breaks
 ## Documentation
 -->
-# 2.2.6
+# 2.2.7
 
 ## Steps
 

--- a/openlane/steps/openroad.py
+++ b/openlane/steps/openroad.py
@@ -1931,6 +1931,7 @@ class CutRows(OpenROADStep):
         return os.path.join(get_script_dir(), "openroad", "cut_rows.tcl")
 
 
+@Step.factory.register()
 class WriteViews(OpenROADStep):
     """
     Write various layout views of an ODB design

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openlane"
-version = "2.2.6"
+version = "2.2.7"
 description = "An infrastructure for implementing chip design flows"
 authors = ["Efabless Corporation and Contributors <donn@efabless.com>"]
 readme = "Readme.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openlane"
-version = "2.2.5"
+version = "2.2.6"
 description = "An infrastructure for implementing chip design flows"
 authors = ["Efabless Corporation and Contributors <donn@efabless.com>"]
 readme = "Readme.md"


### PR DESCRIPTION
* `OpenROAD.WriteViews`
  * Fixed step not being registered to factory object.
 
---
It was accidentally removed in https://github.com/efabless/openlane2/pull/280