### PR TITLE
bugfix: changed TIMING_VIOLATION_CORNERS to a PDK variable

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -13,6 +13,14 @@
 ## API Breaks
 ## Documentation
 -->
+# 2.2.8
+
+## Steps
+
+* `Checker.*Violations`
+
+  * Changed `TIMING_VIOLATION_CORNERS` to a PDK variable
+
 # 2.2.7
 
 ## Steps

--- a/openlane/config/pdk_compat.py
+++ b/openlane/config/pdk_compat.py
@@ -228,6 +228,7 @@ def migrate_old_config(config: Mapping[str, Any]) -> Dict[str, Any]:
             ]
 
         new["DEFAULT_CORNER"] = f"nom_{default_pvt}"
+        new["TIMING_VIOLATION_CORNERS"] = ["*tt*"]
         new["LIB"] = lib_sta
 
     # x4. Constraints (sky130/gf180mcu)

--- a/openlane/steps/checker.py
+++ b/openlane/steps/checker.py
@@ -464,7 +464,7 @@ class TimingViolations(MetricChecker):
                 cls.base_corner_var_name,
                 List[str],
                 "A list of wildcards matching IPVT corners to use during checking for timing violations.",
-                default=["*tt*"],
+                pdk=True,
                 deprecated_names=["TIMING_VIOLATIONS_CORNERS"],
             ),
             cls.get_corner_variable(),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openlane"
-version = "2.2.7"
+version = "2.2.8"
 description = "An infrastructure for implementing chip design flows"
 authors = ["Efabless Corporation and Contributors <donn@efabless.com>"]
 readme = "Readme.md"


### PR DESCRIPTION
## Steps

* `Checker.*Violations`

  * Changed `TIMING_VIOLATION_CORNERS` to a PDK variable