### PR TITLE
bugfix: VERILOG_INCLUDE_DIRS not a list of Paths

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -13,13 +13,24 @@
 ## API Breaks
 ## Documentation
 -->
+
+# 2.2.9
+
+## Steps
+
+* `Yosys.JsonHeader`, `Yosys.Synthesis`
+
+  * Fixed `VERILOG_INCLUDE_DIRS` being a list of strings instead of a list of
+    `Path`s.
+
 # 2.2.8
 
 ## Steps
 
 * `Checker.*Violations`
 
-  * Changed `TIMING_VIOLATION_CORNERS` to a PDK variable
+  * Changed `TIMING_VIOLATION_CORNERS` to a PDK variable to avoid breaking PDKs
+    without `tt` in corner names.
 
 # 2.2.7
 
@@ -35,13 +46,13 @@
 
 * `OpenROAD.ResizerTimingPostGRT`
 
-  * Fixed `GRT_RESIZER_GATE_CLONING` incorrectly applied to hold fixing instead 
-  of setup fixing.
+  * Fixed `GRT_RESIZER_GATE_CLONING` incorrectly applied to hold fixing instead
+    of setup fixing.
 
 * `OpenROAD.ResizerTimingPostCTS`
 
-  * Fixed `PL_RESIZER_GATE_CLONING` incorrectly applied to hold fixing instead 
-  of setup fixing.
+  * Fixed `PL_RESIZER_GATE_CLONING` incorrectly applied to hold fixing instead
+    of setup fixing.
 
 # 2.2.5
 

--- a/openlane/steps/pyosys.py
+++ b/openlane/steps/pyosys.py
@@ -28,44 +28,6 @@ from ..state import State, DesignFormat
 from ..logging import debug, verbose
 from ..common import Path, get_script_dir, process_list_file
 
-verilog_rtl_cfg_vars = [
-    Variable(
-        "VERILOG_FILES",
-        List[Path],
-        "The paths of the design's Verilog files.",
-    ),
-    Variable(
-        "VERILOG_DEFINES",
-        Optional[List[str]],
-        "Preprocessor defines for input Verilog files.",
-        deprecated_names=["SYNTH_DEFINES"],
-    ),
-    Variable(
-        "VERILOG_POWER_DEFINE",
-        Optional[str],
-        "Specifies the name of the define used to guard power and ground connections in the input RTL.",
-        deprecated_names=["SYNTH_USE_PG_PINS_DEFINES", "SYNTH_POWER_DEFINE"],
-        default="USE_POWER_PINS",
-    ),
-    Variable(
-        "VERILOG_INCLUDE_DIRS",
-        Optional[List[str]],
-        "Specifies the Verilog `include` directories.",
-    ),
-    Variable(
-        "USE_SYNLIG",
-        bool,
-        "Use the Synlig plugin to process files, which has better SystemVerilog parsing capabilities but may not be compatible with all Yosys commands and attributes.",
-        default=False,
-    ),
-    Variable(
-        "SYNLIG_DEFER",
-        bool,
-        "Uses -defer flag when reading files the Synlig plugin, which may improve performance by reading each file separately, but is experimental.",
-        default=False,
-    ),
-]
-
 starts_with_whitespace = re.compile(r"^\s+.+$")
 
 yosys_cell_rx = r"cell\s+\S+\s+\((\S+)\)"
@@ -149,7 +111,7 @@ verilog_rtl_cfg_vars = [
     ),
     Variable(
         "VERILOG_INCLUDE_DIRS",
-        Optional[List[str]],
+        Optional[List[Path]],
         "Specifies the Verilog `include` directories.",
     ),
     Variable(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openlane"
-version = "2.2.8"
+version = "2.2.9"
 description = "An infrastructure for implementing chip design flows"
 authors = ["Efabless Corporation and Contributors <donn@efabless.com>"]
 readme = "Readme.md"


### PR DESCRIPTION
* `Yosys.JsonHeader`, `Yosys.Synthesis`

  * Fixed `VERILOG_INCLUDE_DIRS` being a list of strings instead of a list of
    `Path`s.


---

Resolves #615 