### PR TITLE
feat: drt layout and drc snapshots

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -22,6 +22,11 @@
   * Added flags `CTS_OBSTRUCTION_AWARE` and `CTS_BALANCE_LEVELS`
   * Added `CTS_SINK_BUFFER_MAX_CAP_DERATE_PCT`
   * Added `CTS_DELAY_BUFFER_DERATE_PCT`
+
+* `OpenROAD.DetailedRouting`
+  * Added `DRT_SAVE_SNAPSHOTS` which enables saving snapshots of the layout each detalied routing iteration.
+  * Added `DRT_SAVE_DRC_REPORT_ITERS`
+
   
 ## Tool Updates
 

--- a/openlane/scripts/openroad/drt.tcl
+++ b/openlane/scripts/openroad/drt.tcl
@@ -25,13 +25,24 @@ set max_layer $::env(RT_MAX_LAYER)
 if { [info exists ::env(DRT_MAX_LAYER)] } {
     set max_layer $::env(DRT_MAX_LAYER)
 }
-
+if { $::env(DRT_SAVE_SNAPSHOTS) } {
+    set_debug_level DRT snapshot 1
+}
+set drc_report_iter_step_arg ""
+if { $::env(DRT_SAVE_SNAPSHOTS) } {
+    set_debug_level DRT snapshot 1
+    set drc_report_iter_step_arg "-drc_report_iter_step 1"
+}
+if { [info exists ::env(DRT_SAVE_DRC_REPORT_ITERS)] } {
+    set drc_report_iter_step_arg "-drc_report_iter_step $::env(DRT_SAVE_DRC_REPORT_ITERS)"
+}
 detailed_route\
     -bottom_routing_layer $min_layer\
     -top_routing_layer $max_layer\
     -output_drc $::env(STEP_DIR)/$::env(DESIGN_NAME).drc\
     -droute_end_iter $::env(DRT_OPT_ITERS)\
     -or_seed 42\
-    -verbose 1
+    -verbose 1\
+    {*}$drc_report_iter_step_arg
 
 write_views

--- a/openlane/steps/openroad.py
+++ b/openlane/steps/openroad.py
@@ -294,6 +294,7 @@ class OpenROADStep(TclStep):
             command,
             env=env,
             check=check,
+            cwd=self.step_dir,
             **kwargs,
         )
 
@@ -1629,6 +1630,17 @@ class DetailedRouting(OpenROADStep):
             int,
             "Specifies the maximum number of optimization iterations during Detailed Routing in TritonRoute.",
             default=64,
+        ),
+        Variable(
+            "DRT_SAVE_SNAPSHOTS",
+            bool,
+            "Saves an odb snapshot of the layout each routing iteration",
+            default=False,
+        ),
+        Variable(
+            "DRT_SAVE_DRC_REPORT_ITERS",
+            Optional[int],
+            "Report DRC on each specified iteration. Set to 1 when DRT_SAVE_DRC_REPORT_ITERS in enabled",
         ),
     ]
 


### PR DESCRIPTION
## Steps

* `OpenROAD.DetailedRouting`
  * Added `DRT_SAVE_SNAPSHOTS` which enables saving snapshots of the layout each detalied routing iteration.
  * Added `DRT_SAVE_DRC_REPORT_ITERS`
  
---

Partially addresses #618 