### PR TITLE
bugfix: `OpenROAD.Floorplan` core area calculation

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,17 @@
 ## Documentation
 -->
 
+# 2.3.3
+
+## Steps
+
+* `OpenROAD.Floorplan`
+
+  * Fixed an issue in `FP_SIZING`: `absolute` mode where if the die area's
+    x0 > x1 or y0 > y1, the computed core area would no longer fit in the die
+    area. Not that we recommend you ever do that, but technically OpenROAD
+    allows it.
+
 # 2.3.2
 
 ## Steps

--- a/openlane/scripts/openroad/floorplan.tcl
+++ b/openlane/scripts/openroad/floorplan.tcl
@@ -56,17 +56,20 @@ if {$::env(FP_SIZING) == "absolute"} {
         exit -1
     }
     if { ! [info exists ::env(CORE_AREA)] } {
-        set die_ll_x [lindex $::env(DIE_AREA) 0]
-        set die_ll_y [lindex $::env(DIE_AREA) 1]
-        set die_ur_x [lindex $::env(DIE_AREA) 2]
-        set die_ur_y [lindex $::env(DIE_AREA) 3]
+        set die_x0 [lindex $::env(DIE_AREA) 0]
+        set die_y0 [lindex $::env(DIE_AREA) 1]
+        set die_x1 [lindex $::env(DIE_AREA) 2]
+        set die_y1 [lindex $::env(DIE_AREA) 3]
 
-        set core_ll_x [expr {$die_ll_x + $left_margin}]
-        set core_ll_y [expr {$die_ll_y + $bottom_margin}]
-        set core_ur_x [expr {$die_ur_x - $right_margin}]
-        set core_ur_y [expr {$die_ur_y - $top_margin}]
+        set x_dir [expr $die_x1 < $die_x0]
+        set y_dir [expr $die_y1 < $die_y0]
 
-        set ::env(CORE_AREA) [list $core_ll_x $core_ll_y $core_ur_x $core_ur_y]
+        set core_x0 [expr {$die_x0 + (-1 ** $x_dir) * $left_margin}]
+        set core_y0 [expr {$die_y0 + (-1 ** $y_dir) * $bottom_margin}]
+        set core_x1 [expr {$die_x1 - (-1 ** $x_dir) * $right_margin}]
+        set core_y1 [expr {$die_y1 - (-1 ** $y_dir) * $top_margin}]
+
+        set ::env(CORE_AREA) [list $core_x0 $core_y0 $core_x1 $core_y1]
     } else {
         if { [llength $::env(CORE_AREA)] != 4 } {
             puts stderr "Invalid core area string '$::env(CORE_AREA)'."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openlane"
-version = "2.3.2"
+version = "2.3.3"
 description = "An infrastructure for implementing chip design flows"
 authors = ["Efabless Corporation and Contributors <donn@efabless.com>"]
 readme = "Readme.md"


### PR DESCRIPTION
* `OpenROAD.Floorplan`

  * Fixed an issue in `FP_SIZING`: `absolute` mode where if the die area's x0 > x1 or y0 > y1, the computed core area would no longer fit in the die area. Not that we recommend you ever do that, but technically OpenROAD allows it.