### PR TITLE
fix: update nix-eda for python overlays

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,13 @@
 ## Documentation
 -->
 
+# 2.3.4
+
+## Tool Updates
+
+* `nix-eda` updated to 2.1.2
+  * Pulls in a Python overlay fix and a fix for `gdstk`.
+
 # 2.3.3
 
 ## Steps

--- a/flake.lock
+++ b/flake.lock
@@ -81,15 +81,16 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1730973643,
-        "narHash": "sha256-8ZeUxluUbUD3IF0thq4Alioy3JaEVR0AY5+7PuFypBE=",
+        "lastModified": 1739270631,
+        "narHash": "sha256-oHYbSYKq1hCPOALhuzmovvLo8rjWsQsMcfXni8b+ajo=",
         "owner": "efabless",
         "repo": "nix-eda",
-        "rev": "1f8771758e26ad96da4947ed1b17e3942f978cfa",
+        "rev": "8200035e013b010c6fa396e9f826dd2837774686",
         "type": "github"
       },
       "original": {
         "owner": "efabless",
+        "ref": "2.1.2",
         "repo": "nix-eda",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -24,7 +24,7 @@
   };
 
   inputs = {
-    nix-eda.url = github:efabless/nix-eda;
+    nix-eda.url = github:efabless/nix-eda/2.1.2;
     libparse.url = github:efabless/libparse-python;
     ioplace-parser.url = github:efabless/ioplace_parser;
     volare.url = github:efabless/volare;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openlane"
-version = "2.3.3"
+version = "2.3.4"
 description = "An infrastructure for implementing chip design flows"
 authors = ["Efabless Corporation and Contributors <donn@efabless.com>"]
 readme = "Readme.md"


### PR DESCRIPTION
nix-eda 2.1.1 has an issue where Python overlays don't work properly AND gds-tk does not build successfully on Linux.