### PR TITLE
feat: add optional PDK variable to flip placement sites

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -28,10 +28,13 @@
   * `PDN_OBSTRUCTIONS` and `ROUTING_OBSTRUCTIONS` are now lists of tuples
     instead of variable-length Tcl-style lists (AKA: strings).
 
-* `Odb.DiodesOnPorts`, `Odb.PortDiodePlacement`, `Odb.FuzzyDiodePlacement`,
-  `Odb.HeuristicDiodeInsertion`
-
+* `Odb.DiodesOnPorts`, `Odb.PortDiodePlacement`
   * Steps no longer assume `DIODE_CELL` exists and fall back to doing nothing.
+
+*  `Odb.FuzzyDiodePlacement`, `Odb.HeuristicDiodeInsertion`
+  * Steps no longer assume `DIODE_CELL` exists and fall back to doing nothing.
+  * `HEURISTIC_ANTENNA_THRESHOLD` has been made optional, steps do nothing if
+    it is unset.
 
 * `OpenROAD.*`
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -82,6 +82,14 @@
   * Creates three reports to help verify that the RC values used for estimation
     are set correctly.
 
+* `OpenROAD.Floorplan`
+
+  * Added `FP_FLIP_SITES`: allows sites in floorplans to be flipped. Useful in
+    niche alignment scenarios where single-height cells have ground at the south
+    side and double-height cells have power at the south side, causing a short.
+    In that situation, flipping the sites for single-height cells resolves the
+    issue.
+
 * `OpenROAD.GlobalPlacement`
 
   * Added optional variable `PL_ROUTABILITY_MAX_DENSITY_PCT`

--- a/openlane/scripts/odbpy/diodes.py
+++ b/openlane/scripts/odbpy/diodes.py
@@ -330,8 +330,8 @@ class DiodeInserter:
     "--threshold",
     "threshold_microns",
     type=Decimal,
-    default=None,
-    help="Minimum Manhattan distance of a net to be considered an antenna risk requiring a diode. By default, the value used is 200 * the minimum site width.",
+    required=True,
+    help="Minimum Manhattan distance of a net to be considered an antenna risk requiring a diode.",
 )
 @click_odb
 def place(

--- a/openlane/scripts/openroad/floorplan.tcl
+++ b/openlane/scripts/openroad/floorplan.tcl
@@ -97,6 +97,8 @@ if { [info exists ::env(FP_OBSTRUCTIONS)] } {
     }
 }
 
+append_if_exists_argument arg_list FP_FLIP_SITES -flip_sites
+
 log_cmd initialize_floorplan {*}$arg_list
 
 insert_tiecells $::env(SYNTH_TIELO_CELL) -prefix "TIE_ZERO_"

--- a/openlane/steps/odb.py
+++ b/openlane/steps/odb.py
@@ -789,7 +789,7 @@ class FuzzyDiodePlacement(OdbpyStep):
     config_vars = [
         Variable(
             "HEURISTIC_ANTENNA_THRESHOLD",
-            Decimal,
+            Optional[Decimal],
             "A Manhattan distance above which a diode is recommended to be inserted by the heuristic inserter. If not specified, the heuristic algorithm.",
             units="µm",
             pdk=True,
@@ -812,20 +812,14 @@ class FuzzyDiodePlacement(OdbpyStep):
     def get_command(self) -> List[str]:
         cell, pin = self.config["DIODE_CELL"].split("/")
 
-        threshold_opts = []
-        if threshold := self.config["HEURISTIC_ANTENNA_THRESHOLD"]:
-            threshold_opts = ["--threshold", threshold]
-
-        return (
-            super().get_command()
-            + [
-                "--diode-cell",
-                cell,
-                "--diode-pin",
-                pin,
-            ]
-            + threshold_opts
-        )
+        return super().get_command() + [
+            "--diode-cell",
+            cell,
+            "--diode-pin",
+            pin,
+            "--threshold",
+            str(self.config["HEURISTIC_ANTENNA_THRESHOLD"]),
+        ]
 
     def run(self, state_in: State, **kwargs) -> Tuple[ViewsUpdate, MetricsUpdate]:
         if self.config["GPL_CELL_PADDING"] == 0:
@@ -835,6 +829,10 @@ class FuzzyDiodePlacement(OdbpyStep):
 
         if self.config["DIODE_CELL"] is None:
             info(f"'DIODE_CELL' not set. Skipping '{self.id}'…")
+            return {}, {}
+
+        if self.config["HEURISTIC_ANTENNA_THRESHOLD"] is None:
+            info(f"'HEURISTIC_ANTENNA_THRESHOLD' not set. Skipping '{self.id}'…")
             return {}, {}
 
         return super().run(state_in, **kwargs)
@@ -875,6 +873,10 @@ class HeuristicDiodeInsertion(CompositeStep):
         if self.config["DIODE_CELL"] is None:
             info(f"'DIODE_CELL' not set. Skipping '{self.id}'…")
             return {}, {}
+        if self.config["HEURISTIC_ANTENNA_THRESHOLD"] is None:
+            info(f"'HEURISTIC_ANTENNA_THRESHOLD' not set. Skipping '{self.id}'…")
+            return {}, {}
+
         return super().run(state_in, **kwargs)
 
 

--- a/openlane/steps/openroad.py
+++ b/openlane/steps/openroad.py
@@ -975,6 +975,12 @@ class Floorplan(OpenROADStep):
 
     config_vars = OpenROADStep.config_vars + [
         Variable(
+            "FP_FLIP_SITES",
+            Optional[List[str]],
+            "Flip these sites vertically. Useful in niche alignment scenarios where single-height cells have ground at the south side and double-height cells have power at the south side, causing a short. In that situation, flipping the sites for single-height cells resolves the issue.",
+            pdk=True,
+        ),
+        Variable(
             "FP_TRACKS_INFO",
             Path,
             "A path to the a classic OpenROAD `.tracks` file. Used by the floorplanner to generate tracks.",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openlane"
-version = "3.0.0.dev17"
+version = "3.0.0.dev18"
 description = "An infrastructure for implementing chip design flows"
 authors = ["Efabless Corporation and Contributors <donn@efabless.com>"]
 readme = "Readme.md"


### PR DESCRIPTION
This helps with a proprietary PDK.

Also make HEURISTIC_ANTENNA_THRESHOLD optional, missed in #662. Also helps with a proprietary PDK.