### PR TITLE
bugfix: No $scopeinfo cell when flattening in ELABORATE_ONLY mode

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,14 @@
 ## Documentation
 -->
 
+# 2.3.10
+
+## Steps
+
+* `Yosys.Synthesis`
+  * `SYNTH_ELABORATE_FLATTEN` now passes the `-noscopeinfo` flag so scopeinfo
+    cells are no longer emitted from Synthesis.
+
 # 2.3.9
 
 ## Tool Updates

--- a/openlane/scripts/pyosys/synthesize.py
+++ b/openlane/scripts/pyosys/synthesize.py
@@ -309,7 +309,7 @@ def synthesize(
     if config["SYNTH_ELABORATE_ONLY"]:
         openlane_proc(d, report_dir)
         if config["SYNTH_ELABORATE_FLATTEN"]:
-            d.run_pass("flatten")
+            d.run_pass("flatten", "-noscopeinfo")
         d.run_pass("setattr", "-set", "keep", "1")
         d.run_pass("splitnets")
         d.run_pass("opt_clean", "-purge")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openlane"
-version = "2.3.9"
+version = "2.3.10"
 description = "An infrastructure for implementing chip design flows"
 authors = ["Efabless Corporation and Contributors <donn@efabless.com>"]
 readme = "Readme.md"


### PR DESCRIPTION
Fixes #675