### PR TITLE
scl_config_path, in config.py, had wrong definition.

### DIFF
--- a/openlane/config/config.py
+++ b/openlane/config/config.py
@@ -832,7 +832,7 @@ class Config(GenericImmutableDict[str, Any]):
         ), "Fatal error: STD_CELL_LIBRARY default value not set by PDK."
 
         scl_config_path = os.path.join(
-            pdkpath, "libs.tech", "openlane", scl, "config.tcl"
+            pdkpath, "libs.tech", scl, "openlane", "config.tcl"
         )
 
         scl_env = migrate_old_config(


### PR DESCRIPTION
The `openlane2/openlane/config/config.py` had a wrong definition of the variable `scl_config_path`.

Was `slc_config_path = os.path.join(pdkpath, "libs.tech", "openlane", scl, "config.tcl")`.
Should be `slc_config_path = os.path.join(pdkpath, "libs.tech", scl, "openlane", "config.tcl")`.

Affected non-volare pdks, with path error.
Now it's in agreement with [documentation](https://openlane2.readthedocs.io/en/latest/usage/about_pdks.html).