### PR TITLE
nix: backport OpenROAD negative hold/setup margin support

### DIFF
--- a/nix/openroad.nix
+++ b/nix/openroad.nix
@@ -62,6 +62,7 @@
     
     patches = [
       ./patches/openroad/6743.patch
+      ./patches/openroad/negative-margins.patch
     ];
 
     cmakeFlagsAll = [

--- a/nix/patches/openroad/negative-margins.patch
+++ b/nix/patches/openroad/negative-margins.patch
@@ -1,0 +1,28 @@
+From 04312d7e14d95efe49f27061dda49f87eaed8cbf Mon Sep 17 00:00:00 2001
+From: Eder Monteiro <emrmonteiro@precisioninno.com>
+Date: Wed, 23 Oct 2024 11:40:29 -0300
+Subject: [PATCH] rsz: allow negative hold and setup margins
+
+Backport of The-OpenROAD-Project/OpenROAD@04312d7e14d9.
+Allows repair_timing -hold_margin and -setup_margin to accept
+negative values, enabling users to skip minor hold violations
+(e.g., -hold_margin -0.5 means "only fix violations worse than
+-0.5ns").
+
+Signed-off-by: Eder Monteiro <emrmonteiro@precisioninno.com>
+---
+ src/rsz/src/Resizer.tcl | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/rsz/src/Resizer.tcl b/src/rsz/src/Resizer.tcl
+--- a/src/rsz/src/Resizer.tcl
++++ b/src/rsz/src/Resizer.tcl
+@@ -655,7 +655,7 @@ proc parse_margin_arg { key keys_var } {
+   set margin 0.0
+   if { [info exists keys($key)] } {
+     set margin $keys($key)
+-    sta::check_positive_float $key $margin
++    sta::check_float $key $margin
+   }
+   return $margin
+ }


### PR DESCRIPTION
## Summary
- Backports OpenROAD commit 04312d7e ("rsz: allow negative hold and setup margins", Oct 23 2024) as a nix patch
- Changes `check_positive_float` to `check_float` in `parse_margin_arg` in `src/rsz/src/Resizer.tcl`
- Enables `repair_timing -hold_margin -0.5` to skip minor hold violations, matching ORFS's `HOLD_SLACK_MARGIN` behavior

## Why
The pinned OpenROAD (edf00dff, Oct 2 2024) rejects negative `-hold_margin` values with `[STA-0572] -hold_margin '-0.5' is not a positive float`. ORFS relies on negative margins for designs with many structural hold violations on macro pins (e.g., SRAM data inputs with clock insertion delay mismatch). Without this, `repair_timing` either hangs trying to fix thousands of unfixable violations or users must skip hold repair entirely.

## Test plan
- [ ] `nix build` completes (patch applies cleanly)
- [ ] `repair_timing -hold -hold_margin -0.5` accepted without error
- [ ] Existing tests pass (the change only relaxes input validation)